### PR TITLE
Finish PR #87 macOS port: cross-platform fixes + gap report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Java 25 is now required to run the software. The installer will include it.
 - #87 - Experimental macOS support (community contributed by Choaterboater, ported to the new Quarkus build). Device volume/mute/default-device switching via Core Audio, keystrokes, shortcuts and Music/Spotify media control. Per-application volume is not possible on stock macOS. See the [macOS instructions](mac.md).
+- Profiles are now saved on application exit, so a change made right before quitting is no longer lost.
 - Added support for Elgato Wave Link, enable it in the settings to add the dial/button commands
     - Input devices not yet supported (I don't have one so can't debug)
     - Dials/sliders allow changing volume for Channels, Mixes and Output devices

--- a/src/main/java/com/getpcpanel/commands/command/CommandVolumeDefaultDeviceAdvanced.java
+++ b/src/main/java/com/getpcpanel/commands/command/CommandVolumeDefaultDeviceAdvanced.java
@@ -12,8 +12,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.jackson.Jacksonized;
+import lombok.extern.log4j.Log4j2;
 
 @Getter
+@Log4j2
 @Builder
 @Jacksonized
 @AllArgsConstructor
@@ -27,7 +29,12 @@ public class CommandVolumeDefaultDeviceAdvanced extends CommandVolume implements
 
     @Override
     public void execute() {
-        var windowsSndCtrl = CdiHelper.getBean(SndCtrlWindows.class);
+        var windowsSndCtrlOpt = CdiHelper.getOptionalBean(SndCtrlWindows.class);
+        if (windowsSndCtrlOpt.isEmpty()) {
+            log.warn("The default device (advanced) command is only available on Windows");
+            return;
+        }
+        var windowsSndCtrl = windowsSndCtrlOpt.get();
         windowsSndCtrl.setDefaultDevice(mediaPb, DataFlow.dfRender, Role.roleMultimedia);
         windowsSndCtrl.setDefaultDevice(mediaRec, DataFlow.dfCapture, Role.roleMultimedia);
         windowsSndCtrl.setDefaultDevice(communicationPb, DataFlow.dfRender, Role.roleCommunications);

--- a/src/main/java/com/getpcpanel/hid/HidDebug.java
+++ b/src/main/java/com/getpcpanel/hid/HidDebug.java
@@ -15,7 +15,7 @@ public class HidDebug {
 
     @SneakyThrows
     public HidDebug() {
-        var outputFile = new File(System.getenv("USERPROFILE") + "/.pcpanel/hid-debug.txt");
+        var outputFile = new File(System.getProperty("user.home") + "/.pcpanel/hid-debug.txt");
         outputFile.getParentFile().mkdirs();
         writer = new PrintWriter(new FileOutputStream(outputFile));
     }
@@ -47,6 +47,8 @@ public class HidDebug {
             @Override public void hidFailure(HidServicesEvent event) {
                 write("Hid failure: " + event);
             }
+            // Note: PR #87 also added a hidDataReceived(...) override, but that listener method only
+            // exists in hid4java 0.8+. 2.0 is still on 0.7.0; restore it together with the hid4java bump.
         };
     }
 

--- a/src/main/java/com/getpcpanel/profile/SaveService.java
+++ b/src/main/java/com/getpcpanel/profile/SaveService.java
@@ -17,6 +17,7 @@ import com.getpcpanel.hid.DeviceHolder;
 import com.getpcpanel.util.Debouncer;
 import com.getpcpanel.util.FileUtil;
 
+import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Priority;
@@ -40,6 +41,7 @@ public class SaveService {
 
     private Save save;
     private boolean isNew = false;
+    private volatile boolean loadFailed;
 
     public Save get() {
         return save;
@@ -64,6 +66,7 @@ public class SaveService {
             StreamEx.ofValues(save.getDevices()).forEach(d -> StreamEx.of(d.getProfiles()).findFirst(p -> p.isMainProfile()).ifPresent(p -> d.setCurrentProfile(p.getName())));
         } catch (Exception e) {
             log.error("Unable to read file", e);
+            loadFailed = true; // Prevent save-on-exit from overwriting a file we could not read
             save = new Save();
             isNew = true;
         }
@@ -86,10 +89,11 @@ public class SaveService {
         writeToFile(); // write file only, SaveEvent will be fired from onStart()
     }
 
-    private void writeToFile() {
+    private synchronized void writeToFile() { // Synchronized: a pending debounced save may run concurrently with the shutdown write
         var saveFile = fileUtil.getFile(saveFileName);
         try {
             FileUtils.writeStringToFile(saveFile, json.writePretty(save), Charset.defaultCharset());
+            loadFailed = false; // The file now holds the in-memory state, so save-on-exit can no longer destroy anything
         } catch (IOException e) {
             log.error("Unable to save file", e);
         }
@@ -111,7 +115,11 @@ public class SaveService {
     }
 
     private void tryMigrate(File saveFile) {
-        @SuppressWarnings("CallToSystemGetenv") var oldFile = new File(System.getenv("LOCALAPPDATA"), "PCPanel Software/save.json");
+        @SuppressWarnings("CallToSystemGetenv") var localAppData = System.getenv("LOCALAPPDATA");
+        if (localAppData == null) { // Not Windows: nothing to migrate from
+            return;
+        }
+        var oldFile = new File(localAppData, "PCPanel Software/save.json");
         if (oldFile.exists()) {
             var result = JOptionPane.showConfirmDialog(null, "No save file found, would you like to migrate from original PCPanel software?", "Migrate", JOptionPane.YES_NO_OPTION);
             if (result == JOptionPane.YES_OPTION) {
@@ -132,6 +140,19 @@ public class SaveService {
 
     public void debouncedSave() {
         debouncer.debounce(this, this::save, 1, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Persist the in-memory state when the app shuts down, so a profile change made within the
+     * debounce window (the {@link Debouncer} discards pending tasks on shutdown) is not lost.
+     * Writes the file directly without firing a SaveEvent: listeners (OBS/MQTT/OSC/...) must not
+     * run while beans are being destroyed.
+     */
+    public void saveOnExit(@Observes ShutdownEvent ev) {
+        if (save == null || loadFailed) {
+            return;
+        }
+        writeToFile();
     }
 
     public Optional<Profile> getProfile(String serialNum) {

--- a/src/main/java/com/getpcpanel/util/CdiHelper.java
+++ b/src/main/java/com/getpcpanel/util/CdiHelper.java
@@ -1,5 +1,7 @@
 package com.getpcpanel.util;
 
+import java.util.Optional;
+
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.spi.CDI;
@@ -11,5 +13,17 @@ import jakarta.enterprise.inject.spi.CDI;
 public class CdiHelper {
     public static <T> T getBean(Class<T> clazz) {
         return CDI.current().select(clazz).get();
+    }
+
+    /**
+     * Resolves a bean that may be absent in the current platform build (e.g. {@code SndCtrlWindows}
+     * is only present on a Windows build), returning empty instead of throwing when unresolvable.
+     */
+    public static <T> Optional<T> getOptionalBean(Class<T> clazz) {
+        var instance = CDI.current().select(clazz);
+        if (instance.isResolvable()) {
+            return Optional.of(instance.get());
+        }
+        return Optional.empty();
     }
 }

--- a/src/main/java/dev/niels/wavelink/impl/WaveLinkClientImpl.java
+++ b/src/main/java/dev/niels/wavelink/impl/WaveLinkClientImpl.java
@@ -21,6 +21,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -349,9 +350,8 @@ public abstract class WaveLinkClientImpl implements IWaveLinkClient, AutoCloseab
 
     private int getWaveLinkPort() {
         // Just using a static port is too easy for Elgato, so we retrieve the (random?) port from the ws-info.json, just like the StreamDeck does...
-        var userProfile = System.getenv("USERPROFILE");
-        if (!StringUtils.isBlank(userProfile)) {
-            var wsInfoPath = Path.of(userProfile, "AppData", "Local", "Packages", "Elgato.WaveLink_g54w8ztgkx496", "LocalState", "ws-info.json");
+        var wsInfoPath = getWsInfoPath();
+        if (wsInfoPath != null) {
             try {
                 var content = Files.readString(wsInfoPath);
                 var mapper = new ObjectMapper();
@@ -363,5 +363,18 @@ public abstract class WaveLinkClientImpl implements IWaveLinkClient, AutoCloseab
             }
         }
         return DEFAULT_WAVELINK_PORT;
+    }
+
+    @Nullable
+    private Path getWsInfoPath() {
+        var userProfile = System.getenv("USERPROFILE");
+        if (!StringUtils.isBlank(userProfile)) {
+            return Path.of(userProfile, "AppData", "Local", "Packages", "Elgato.WaveLink_g54w8ztgkx496", "LocalState", "ws-info.json");
+        }
+        if (SystemUtils.IS_OS_MAC) {
+            var macPath = Path.of(System.getProperty("user.home"), "Library", "Application Support", "Elgato", "WaveLink", "ws-info.json");
+            return Files.exists(macPath) ? macPath : null;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Context

PR #87 (macOS support, by @Choaterboater) was built on the old Spring Boot + JavaFX
codebase. It was ported to the Quarkus/Angular 2.0 architecture in `0f66af4`. This PR
finishes that port: it restores the **cross-platform / macOS fixes the port missed**, and
documents the remaining gaps.

Attribution for the original contributor has already been handled separately: an `-s ours`
merge of the original commit `0f6bd83` is now in `releases/2.0` history (commit `649a178`,
no file changes), so @Choaterboater is credited in the contributors list. They are also
named in the release notes (`CHANGELOG.md`).

## What this PR fixes (verified: JVM compile + 94/94 tests on GraalVM CE 25)

These came from PR #87 but were in files the port did not touch:

- **Save profiles on exit** (`SaveService`) — Quarkus `@Observes ShutdownEvent`, plus a
  `loadFailed` guard (never overwrite a file we couldn't read) and a `synchronized` write
  (a pending debounced save can't race the shutdown write). The `Debouncer` discards pending
  tasks on shutdown, so without this a profile change made within the 1s debounce window
  before quitting was lost. Cross-platform fix, affects everyone.
- **Wave Link on macOS** (`WaveLinkClientImpl`) — add the
  `~/Library/Application Support/Elgato/WaveLink/ws-info.json` fallback for port discovery.
- **Graceful Windows-only guard** (`CommandVolumeDefaultDeviceAdvanced`) — log + return when
  `SndCtrlWindows` is absent (new `CdiHelper.getOptionalBean`) instead of throwing
  `UnsatisfiedResolutionException` on macOS/Linux.
- **HidDebug** — write to `user.home` instead of Windows-only `USERPROFILE` so `--hiddebug`
  works on macOS/Linux. (Its `hidDataReceived` listener override needs hid4java 0.8 — deferred
  with that bump, see below.)
- **`SaveService.tryMigrate`** — guard a null `LOCALAPPDATA` on non-Windows.

## Verification summary of the whole port

The macOS **backend** port is faithful: CoreAudio (incl. the HDMI/DisplayPort per-channel
volume fallback), SndCtrlOsx, OsxProcessHelper, OsxMediaControl, OsxPermissionHelper,
OsxPlatformCommand, KeyMacro (cmd key + safe modifier release, now via CoreGraphics since the
mac native image has no AWT Robot), CommandMedia mac branch, DeviceScanner permission hints,
and the `@MacBuild` stereotype replacing the old `@ConditionalOnMac`. CSS/FXML and the JavaFX
device/settings/app-finder UIs are correctly obsolete (Angular frontend).

## Remaining gaps — NOT in this PR (need maintainer decisions / Mac+native verification)

1. **hid4java is still 0.7.0** (`pom.xml`). PR #87 bumped it to 0.8.0 specifically because 0.7
   ships only an Intel dylib — **Apple Silicon HID won't work without it**. The bump is *not* a
   one-liner here: `NativeImageConfig.java` registers hid4java's internal JNA classes
   (`HidApiLibrary`, `HidrawHidApiLibrary`, `LibusbHidApiLibrary`, `WideStringBuffer`) for
   GraalVM reflection, and 0.8 refactored those. Needs the bump + `NativeImageConfig` rework +
   a native build verified on each platform (incl. a Mac). This is the #1 blocker for the
   feature actually working on Apple Silicon.
2. **OS-availability "grey-out" UX** — PR #87's most visible UX feature was dropped in the
   architecture change. Old arch used `@Cmd(os=...)` + per-controller annotations so commands
   unavailable on the current OS render greyed-out with a reason, and foreign-OS mappings stay
   visible/deletable. 2.0 has **no** per-OS command metadata: `CommandType` has no `os` field,
   `CommandsResource.listAvailableCommands()` doesn't filter by OS, and the Angular picker has
   no disabled/reason rendering. Result: on macOS, Focus Mute / VoiceMeeter / App Volume /
   Focus Volume are offered but silently do nothing (runtime is safe — they no-op/log — but the
   UX is confusing). Foreign-OS mappings happen to survive via a generic "Unknown command type"
   fallback, but not intentionally. Restoring this is a cross-stack feature (DTO + resource +
   Angular + regenerated TS types).
3. **IconServiceMac is a no-op stub** — the PR's sips/plutil icon-extraction was not carried
   over (justified: the mac native image has no AWT/`BufferedImage`), so macOS shows default
   icons. The port commit message inaccurately advertises "IconServiceMac (sips/plutil)";
   worth correcting, or implementing a non-AWT (NSWorkspace/Quartz) path if per-app icons are
   wanted on mac.
4. **No macOS tray/dock** — 2.0 intentionally runs no AWT tray on macOS, so PR #87's
   Dock-reopen / "Show PCPanel" handling is absent on mac. Also the cross-platform "Show
   PCPanel" tray menu item is missing on all platforms (only "Exit" is shown).
5. Minor: no JVM uncaught-exception handler; overlay lost the multi-monitor visual-bounds
   offset (can misposition off a non-primary / non-zero-origin display).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
