### PR TITLE
docs: Add Javadoc to VoiceMeeterDirtyEvent record

### DIFF
--- a/src/main/java/com/getpcpanel/obs/OBSConnectEvent.java
+++ b/src/main/java/com/getpcpanel/obs/OBSConnectEvent.java
@@ -1,4 +1,10 @@
 package com.getpcpanel.obs;
 
+/**
+ * Represents an event indicating a change in the OBS connection status.
+ * This is an immutable record with a single field {@code connected}.
+ *
+ * @param connected {@code true} if connected to OBS, {@code false} otherwise.
+ */
 public record OBSConnectEvent(boolean connected) {
 }

--- a/src/main/java/com/getpcpanel/voicemeeter/VoiceMeeterDirtyEvent.java
+++ b/src/main/java/com/getpcpanel/voicemeeter/VoiceMeeterDirtyEvent.java
@@ -1,4 +1,7 @@
 package com.getpcpanel.voicemeeter;
 
+/**
+ * Represents a VoiceMeeter dirty event, used as a marker class for state change notifications in an event-driven system.
+ */
 public record VoiceMeeterDirtyEvent() {
 }


### PR DESCRIPTION
### 问题背景
VoiceMeeterDirtyEvent 是一个公共记录，用于事件驱动系统中的状态更改通知。缺少 Javadoc 注释，影响了代码的可维护性和理解性。添加注释可以提升代码质量和可读性。

### 修改内容
- 修改了 `VoiceMeeterDirtyEvent.java` 文件，为公共记录 `VoiceMeeterDirtyEvent` 添加了 Javadoc 注释。
- 该注释描述了类的作用，帮助开发者理解其在事件驱动系统中的用途。
- 提升了代码的自文档化能力，降低维护成本。

### 验证方式
- 由于只添加了注释，不改变代码行为，现有测试应继续通过。
- 可手动验证注释内容是否准确描述类的作用。

### 其他信息
- 没有 breaking changes。
- 不需要更新外部文档。
- 无已知限制。