### PR TITLE
fix(macos): register JNA pointer types for CoreAudio reflection

### DIFF
--- a/src/main/java/com/getpcpanel/graalvm/NativeImageConfig.java
+++ b/src/main/java/com/getpcpanel/graalvm/NativeImageConfig.java
@@ -372,6 +372,10 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
         "com.sun.jna.platform.mac.CoreFoundation$CFStringRef$ByReference",
         "com.sun.jna.platform.mac.CoreFoundation$CFTypeID",
         "com.sun.jna.platform.mac.CoreFoundation$CFTypeRef",
+        // JNA pointer types used by CoreAudioWrapper (JNA reflectively instantiates these when
+        // marshalling native call arguments — e.g. AudioObjectIsPropertySettable's ByteByReference out-param).
+        "com.sun.jna.ptr.ByteByReference",
+        "com.sun.jna.ptr.IntByReference",
         // Project CoreAudio JNA binding: the property-address Structure (instantiated per call) and the
         // change-listener Callback (used for default-device/volume notifications).
         "com.getpcpanel.cpp.osx.CoreAudioLib$AudioObjectPropertyAddress",


### PR DESCRIPTION
## Summary

- Registers `com.sun.jna.ptr.ByteByReference` and `com.sun.jna.ptr.IntByReference` in `NativeImageConfig` for GraalVM native-image reflection.
- These JNA pointer types are used by `CoreAudioWrapper` for CoreAudio property calls (`AudioObjectIsPropertySettable`, `AudioObjectGetPropertyDataSize`, `AudioObjectGetPropertyData`). JNA reflectively instantiates them when marshalling native call arguments, but they were missing from the reflection config, causing all CoreAudio volume and mute commands to fail with `NoSuchMethodException` in the native image.

Fixes #105

## Test plan

- [x] Built native image on macOS arm64 (GraalVM CE 25)
- [x] Launched the native binary, connected a PCPanel Mini
- [x] Verified CoreAudio volume knob command executes without reflection errors
- [x] Verified CoreAudio mute button command executes without reflection errors
- [x] All 414 unit tests pass