### PR TITLE
fix(dev): reliable backend hot reload (quarkus:dev)

### DIFF
--- a/src/main/java/com/getpcpanel/wavelink/WaveLinkService.java
+++ b/src/main/java/com/getpcpanel/wavelink/WaveLinkService.java
@@ -28,6 +28,7 @@ import dev.niels.wavelink.impl.model.WaveLinkChannel;
 import dev.niels.wavelink.impl.model.WaveLinkInputDevice;
 import dev.niels.wavelink.impl.model.WaveLinkMix;
 import dev.niels.wavelink.impl.model.WaveLinkOutputDevice;
+import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
@@ -286,6 +287,16 @@ public class WaveLinkService extends WaveLinkClient implements IWaveLinkClientEv
 
     public boolean isEnabled() {
         return saveService.get().getWaveLink().enabled();
+    }
+
+    /**
+     * Tears down the Wave Link connection on shutdown — which, in dev mode, fires on every live-reload
+     * restart. Without this the client's websocket/HttpClient worker threads survive into the next
+     * container and keep invoking listener callbacks against the now-dead classloader, throwing
+     * ClassCastException (e.g. {@code DeviceHolder cannot be cast to DeviceHolder}) on each push.
+     */
+    void onShutdown(@Observes ShutdownEvent event) {
+        disconnect();
     }
 
     public void settingsChanged(@Observes SaveEvent event) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,6 +36,15 @@ quarkus.quinoa.enable-spa-routing=true
 %dev.quarkus.quinoa.dev-server.port=4200
 #%dev.linux.commands.kdotool=~/.cargo/bin/kdotool
 
+# ── Dev hot reload ────────────────────────────────────────────────────────────
+# Hot-swap method-body-only edits in place (JVM HotSwap) instead of dropping the app classloader
+# and restarting. This is what makes iterating on logic survive without re-initialising the native
+# subsystems: a fresh classloader cannot re-System.load() SndCtrl.dll (UnsatisfiedLinkError "already
+# loaded in another classloader") and orphans JNI/Wave Link callback threads that then fire into the
+# new container (ClassCastException). Structural edits (adding/removing a method, field, or bean) still
+# force a full restart. Trade-off: on the hot-swap fast path @PostConstruct/ShutdownEvent do NOT re-run.
+%dev.quarkus.live-reload.instrumentation=true
+
 # Jackson
 quarkus.jackson.fail-on-unknown-properties=false
 


### PR DESCRIPTION
## Problem

In `quarkus:dev`, changing backend Java code broke the running app: Arc/CDI started throwing because the app classloader is replaced on live-reload, so:

- `SndCtrlWindows` re-ran `System.load` on the native DLL → `UnsatisfiedLinkError: SndCtrl.dll already loaded in another classloader` (a native lib can only be bound to one classloader).
- Orphaned JNI / Wave Link callback threads from the old classloader fired into the new container → `ClassCastException: DeviceHolder cannot be cast to DeviceHolder (... QuarkusClassLoader @aaa ... @bbb)`.

## Fix

- **`application.properties` (`%dev`)**: enable `quarkus.live-reload.instrumentation` so method-body-only edits hot-swap in place (JVM HotSwap) without dropping the classloader — no DLL reload, no orphaned threads. Verified: such edits log `Live reload performed via instrumentation, no restart needed` with zero native/classloader errors.
- **`WaveLinkService`**: tear the client down on `ShutdownEvent` (fires on every dev redeploy) so its websocket/HttpClient worker threads don't survive into the next container and fire stale-classloader callbacks.

## Known limitation (intentional, out of scope)

Structural edits (add/remove a method, field, or bean) still force a full restart that re-creates the classloader; SndCtrl's DLL can't reload until you relaunch `quarkus:dev` (~5s). Fully curing that needs isolating the native bridge into its own classloader-stable module — a build-structure change that only benefits dev mode, deliberately not done here. Just restart the dev server after a structural change.

Dev-mode only; the native/production image AOT-compiles everything into one binary and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)