### PR TITLE
Fix: auto-update reinstall-current on the rolling snapshot channel

### DIFF
--- a/src/main/java/com/getpcpanel/util/version/AutoUpdateService.java
+++ b/src/main/java/com/getpcpanel/util/version/AutoUpdateService.java
@@ -95,7 +95,7 @@ public class AutoUpdateService {
 
         var root = objectMapper.readTree(response.body());
         var releases = objectMapper.treeToValue(root, Version[].class);
-        var target = latest ? selectLatest(releases, isSnapshot()) : selectCurrent(releases, currentSemVer(), isSnapshot(), build);
+        var target = chooseTarget(releases, latest, isSnapshot(), currentSemVer(), build);
         if (target == null) {
             throw new UpdateException(latest
                     ? "No suitable release was found to update to."
@@ -107,6 +107,19 @@ public class AutoUpdateService {
             throw new UpdateException("Release " + target.versionDisplay() + " has no Windows installer to download.");
         }
         return new UpdateTarget(target.versionDisplay(), installerUrl);
+    }
+
+    /**
+     * Pick the release to install. {@code latest} = update to the newest available; otherwise reinstall
+     * the current version. Snapshot builds share one rolling pre-release ({@code latest-main}), so there
+     * is no per-build release to match exactly — both paths target the newest pre-release for a snapshot.
+     * A release build has a named release per version, so "reinstall current" matches it exactly.
+     */
+    static Version chooseTarget(Version[] releases, boolean latest, boolean snapshot, SemVer currentSemVer, int build) {
+        if (latest || snapshot) {
+            return selectLatest(releases, snapshot);
+        }
+        return selectCurrent(releases, currentSemVer, snapshot, build);
     }
 
     /** Newest release of the matching type: stable-only for a release build, pre-releases too for a snapshot. */

--- a/src/test/java/com/getpcpanel/util/version/AutoUpdateServiceTest.java
+++ b/src/test/java/com/getpcpanel/util/version/AutoUpdateServiceTest.java
@@ -18,10 +18,37 @@ class AutoUpdateServiceTest {
     void setupAssetPatternMatchesTheCiArtifactOnly() {
         assertTrue(AutoUpdateService.SETUP_ASSET.matcher("PCPanel-1.8.123-setup.exe").matches());
         assertTrue(AutoUpdateService.SETUP_ASSET.matcher("pcpanel-2.0-setup.exe").matches());
+        assertTrue(AutoUpdateService.SETUP_ASSET.matcher("PCPanel-2.0.71-setup.exe").matches()); // real latest-main asset name
         // Not the installer: the Linux artifacts, or a checksum file.
         assertFalse(AutoUpdateService.SETUP_ASSET.matcher("PCPanel-1.8.123.AppImage").matches());
         assertFalse(AutoUpdateService.SETUP_ASSET.matcher("pcpanel_1.8.123_amd64.deb").matches());
         assertFalse(AutoUpdateService.SETUP_ASSET.matcher("PCPanel-setup.exe.sha256").matches());
+    }
+
+    // Real release shapes from the repo: the rolling snapshot channel is one pre-release whose name
+    // carries the build number, e.g. "v2.0-SNAPSHOT Pre-Release (71)", tagged latest-main.
+    @Test
+    void chooseTargetSnapshotAlwaysTakesNewestPreReleaseEvenWhenRunningANewerBuild() {
+        var releases = new Version[] {
+                release(2, "v2.0-SNAPSHOT Pre-Release (71)", true), // published rolling build
+                release(1, "v1.7.1", false),
+        };
+        // Running build 73 (newer than the published 71): reinstall-current must still resolve, to 71,
+        // instead of demanding a non-existent "build 73" release.
+        var current = SemVer.fromName("2.0-SNAPSHOT").withBuild(73);
+        assertEquals(2, AutoUpdateService.chooseTarget(releases, false, true, current, 73).id());
+        assertEquals(2, AutoUpdateService.chooseTarget(releases, true, true, current, 73).id());
+    }
+
+    @Test
+    void chooseTargetReleaseBuildReinstallsTheExactCurrentVersion() {
+        var releases = new Version[] {
+                release(3, "v2.1", false),
+                release(2, "v2.0", false),
+        };
+        assertEquals(2, AutoUpdateService.chooseTarget(releases, false, false, SemVer.fromName("2.0"), -1).id());
+        // ...but "update to latest" jumps to the newest stable.
+        assertEquals(3, AutoUpdateService.chooseTarget(releases, true, false, SemVer.fromName("2.0"), -1).id());
     }
 
     @Test


### PR DESCRIPTION
The Debug **"Re-download & reinstall current version"** button failed on snapshot/`latest-main` builds:

> Update failed — Could not find a release matching the running version (2.0-SNAPSHOT (73)) to reinstall.

**Cause:** snapshot builds all share one rolling pre-release (`latest-main`), so there's no per-build release to match exactly. The running build can even be *newer* than the currently published one — a build's installer is downloadable from its CI run before the `latest-main` release finishes publishing (exactly what happened: build 73 running while the release still showed 71).

**Fix:** for a snapshot build, both "update to latest" and "reinstall current" now target the newest pre-release (the rolling channel) instead of demanding an exact build-number match. Release builds keep exact-version matching. Decision extracted into a unit-tested `chooseTarget()`.

Backend-only; 456 tests pass (incl. new cases for the snapshot-newer-than-published race).

## AI-assisted contribution

This pull request was made by an AI without any human intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)