### PR TITLE
Fix: reload the open tab when the backend updates under it

### DIFF
--- a/src/main/webui/src/app/services/device-state.service.ts
+++ b/src/main/webui/src/app/services/device-state.service.ts
@@ -3,6 +3,7 @@ import { DeviceSnapshotDto, ProfileSnapshotDto, WsAssignmentChangedEvent, WsCont
 import { ToastService } from '../ui/toast/toast.service';
 import { PlatformService } from './platform.service';
 import { UpdateService } from './update.service';
+import { VersionGuardService } from './version-guard.service';
 
 type DeviceMap = Record<string, DeviceSnapshotDto>;
 
@@ -18,6 +19,7 @@ export class DeviceStateService implements OnDestroy {
   private readonly toasts = inject(ToastService);
   private readonly platform = inject(PlatformService);
   private readonly updates = inject(UpdateService);
+  private readonly versionGuard = inject(VersionGuardService);
   private readonly _devices = signal<DeviceMap>({});
   private socket: WebSocket | null = null;
   private reconnectTimer?: ReturnType<typeof setTimeout>;
@@ -86,6 +88,9 @@ export class DeviceStateService implements OnDestroy {
       this.connected.set(true);
       this.reconnecting.set(false);
       this.lastError.set(null);
+      // If the backend came back on a new version (e.g. after an auto-update), reload to swap the stale
+      // frontend bundle for the matching one instead of running the old UI against the new backend.
+      void this.versionGuard.checkOnConnect();
     };
 
     this.socket.onmessage = (event) => {

--- a/src/main/webui/src/app/services/version-guard.service.ts
+++ b/src/main/webui/src/app/services/version-guard.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+
+/**
+ * Reloads the page when the backend version changes underneath an open tab.
+ *
+ * The frontend bundle ships with (and is served by) the backend, so when the backend restarts on a new
+ * version — e.g. after an auto-update — the frontend already loaded in the tab is stale. The websocket
+ * reconnects on its own, but that leaves the old bundle running against the new backend (stale version in
+ * the footer, possibly an incompatible command catalog) until a manual refresh. This guard closes that gap:
+ * on every (re)connect it reads the live backend version and, if it differs from the one the page loaded
+ * with, reloads to pull the matching frontend.
+ *
+ * `index.html` is served `no-cache` (see {@code StaticCacheControl}), so the reload fetches the new bundle
+ * rather than re-serving the stale one — the mismatch resolves in a single reload and cannot loop.
+ */
+@Injectable({ providedIn: 'root' })
+export class VersionGuardService {
+  /** The backend version this page was loaded with; set on the first successful connect. */
+  private baseline: string | null = null;
+
+  /** Call on every websocket (re)connect. */
+  async checkOnConnect(): Promise<void> {
+    let version: string | undefined;
+    try {
+      // no-store: never let a cached response hide a real version change (and /api is exempt from the
+      // no-cache filter, so the browser could otherwise heuristically cache it).
+      const res = await fetch('/api/platform', { cache: 'no-store' });
+      version = (await res.json())?.version;
+    } catch {
+      return; // transient (backend still coming back up) — re-checked on the next reconnect
+    }
+    if (!version) return;
+
+    if (this.baseline === null) {
+      this.baseline = version; // first connect ≈ page load: this is the version we're running
+    } else if (version !== this.baseline) {
+      location.reload();
+    }
+  }
+}


### PR DESCRIPTION
After an auto-update the websocket reconnects, but the already-open tab keeps running the **old frontend bundle** against the new backend — stale version in the footer and a possibly-incompatible UI — until a manual refresh.

**Fix:** `VersionGuardService` — on every websocket (re)connect it reads the live backend version (`/api/platform`, `no-store`) and, if it differs from the version the page loaded with, calls `location.reload()` to pull the matching frontend. `index.html` is served `no-cache` (`StaticCacheControl`), so the reload fetches the new bundle and cannot loop. The "just updated" dialog then shows via the fresh page's normal startup path.

Frontend-only; builds/typechecks.

## AI-assisted contribution

This pull request was made by an AI without any human intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)