### PR TITLE
Auto-update setting + explicit pre-release opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Java 25 is now required to run the software. The installer will include it.
 - The Windows installer now closes a running PCPanel by itself before updating, instead of asking you to close it manually — it shuts the running instance down cleanly (saving your settings) and only force-closes it as a fallback.
 - **One-click updates on Windows**: when a new version is available, the notification's "Update & restart" button now downloads the installer, runs it silently (keeping your existing install location), and restarts the updated app for you — no more clicking through the installer. The page you started from reconnects on its own and confirms with a short "up to date" dialog. On Linux and macOS the notification still links to the download page.
+- New update settings (under "Check for updates on startup"): **Automatically install updates** (Windows only, off by default) applies a newer version on startup without any prompts; and **Check for pre-release versions** opts in to in-development snapshot builds rather than only stable releases.
 - #87 - Experimental macOS support (community contributed by Choaterboater, ported to the new Quarkus build). Device volume/mute/default-device switching via Core Audio, keystrokes, shortcuts and Music/Spotify media control. Per-application volume is not possible on stock macOS. See the [macOS instructions](mac.md).
 - Profiles are now saved on application exit, so a change made right before quitting is no longer lost.
 - Added support for Elgato Wave Link, enable it in the settings to add the dial/button commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,11 @@ install before running Maven, e.g. `export JAVA_HOME=~/.jdks/graalvm-ce-25.0.2`
   native image, exposed to the UI as `PlatformInfo.autoUpdate`; elsewhere (Linux/macOS, dev/JVM) the
   UI links to the release page instead. REST: `POST /api/system/update` (latest) and
   `/api/system/update/reinstall` (the Debug page's reinstall-current button, for testing the flow).
+  Settings (`Save`): `autoUpdate` (Windows-only, off by default) makes `VersionChecker` install a newer
+  version on startup automatically instead of just notifying; `checkForPreReleases` is the explicit
+  opt-in to snapshot/pre-release builds — the "type" of update is no longer derived from whether the
+  running build is a snapshot (that only decides build-number comparison now). Both are only meaningful
+  when `startupVersionCheck` is on, and the UI disables them otherwise.
 
 ### Frontend (`src/main/webui`, Angular 21)
 

--- a/src/main/java/com/getpcpanel/profile/Save.java
+++ b/src/main/java/com/getpcpanel/profile/Save.java
@@ -44,6 +44,12 @@ public class Save {
      *  tray and the UI is opened on demand; a first run and an installer launch open it regardless. */
     private boolean openBrowserOnStartup;
     private boolean startupVersionCheck = true;
+    /** Include pre-release (snapshot) builds when checking for updates. Explicit choice — the running
+     *  build's own snapshot-ness no longer decides this. Only meaningful when startupVersionCheck is on. */
+    private boolean checkForPreReleases;
+    /** Windows only: on startup, download and silently install a newer version (of the chosen type),
+     *  then restart. Off by default; only meaningful when startupVersionCheck is on. */
+    private boolean autoUpdate;
     private boolean forceVolume; // Linux only
     private Long dblClickInterval = 500L;
     private boolean preventClickWhenDblClick = true;

--- a/src/main/java/com/getpcpanel/rest/model/dto/SettingsDto.java
+++ b/src/main/java/com/getpcpanel/rest/model/dto/SettingsDto.java
@@ -21,6 +21,8 @@ public class SettingsDto {
     private boolean mainUIIcons;
     private boolean openBrowserOnStartup;
     private boolean startupVersionCheck;
+    private boolean checkForPreReleases;
+    private boolean autoUpdate;
     private boolean forceVolume;
     private Long dblClickInterval;
     private boolean preventClickWhenDblClick;
@@ -80,6 +82,8 @@ public class SettingsDto {
         dto.mainUIIcons = save.isMainUIIcons();
         dto.openBrowserOnStartup = save.isOpenBrowserOnStartup();
         dto.startupVersionCheck = save.isStartupVersionCheck();
+        dto.checkForPreReleases = save.isCheckForPreReleases();
+        dto.autoUpdate = save.isAutoUpdate();
         dto.forceVolume = save.isForceVolume();
         dto.dblClickInterval = save.getDblClickInterval();
         dto.preventClickWhenDblClick = save.isPreventClickWhenDblClick();
@@ -130,6 +134,8 @@ public class SettingsDto {
         save.setMainUIIcons(mainUIIcons);
         save.setOpenBrowserOnStartup(openBrowserOnStartup);
         save.setStartupVersionCheck(startupVersionCheck);
+        save.setCheckForPreReleases(checkForPreReleases);
+        save.setAutoUpdate(autoUpdate);
         save.setForceVolume(forceVolume);
         save.setDblClickInterval(dblClickInterval);
         save.setPreventClickWhenDblClick(preventClickWhenDblClick);

--- a/src/main/java/com/getpcpanel/util/version/AutoUpdateService.java
+++ b/src/main/java/com/getpcpanel/util/version/AutoUpdateService.java
@@ -49,6 +49,7 @@ public class AutoUpdateService {
     static final Pattern SETUP_ASSET = Pattern.compile("(?i)^pcpanel-.*setup\\.exe$");
 
     @Inject ObjectMapper objectMapper;
+    @Inject com.getpcpanel.profile.SaveService save;
 
     @ConfigProperty(name = "pcpanel.github.user-and-repo") String githubUserAndRepo;
     @ConfigProperty(name = "pcpanel.version") String version;
@@ -95,7 +96,7 @@ public class AutoUpdateService {
 
         var root = objectMapper.readTree(response.body());
         var releases = objectMapper.treeToValue(root, Version[].class);
-        var target = chooseTarget(releases, latest, isSnapshot(), currentSemVer(), build);
+        var target = chooseTarget(releases, latest, save.get().isCheckForPreReleases(), isSnapshot(), currentSemVer(), build);
         if (target == null) {
             throw new UpdateException(latest
                     ? "No suitable release was found to update to."
@@ -110,23 +111,30 @@ public class AutoUpdateService {
     }
 
     /**
-     * Pick the release to install. {@code latest} = update to the newest available; otherwise reinstall
-     * the current version. Snapshot builds share one rolling pre-release ({@code latest-main}), so there
-     * is no per-build release to match exactly — both paths target the newest pre-release for a snapshot.
-     * A release build has a named release per version, so "reinstall current" matches it exactly.
+     * Pick the release to install.
+     * <ul>
+     *   <li>{@code latest} — update to the newest available, filtered by {@code includePrereleases} (the
+     *       user's "check for pre-release versions" choice).</li>
+     *   <li>otherwise — reinstall the current version. A {@code currentIsSnapshot} build has no per-build
+     *       release to match (all snapshots share the rolling {@code latest-main} pre-release), so it
+     *       targets the newest pre-release; a release build matches its exact named release.</li>
+     * </ul>
      */
-    static Version chooseTarget(Version[] releases, boolean latest, boolean snapshot, SemVer currentSemVer, int build) {
-        if (latest || snapshot) {
-            return selectLatest(releases, snapshot);
+    static Version chooseTarget(Version[] releases, boolean latest, boolean includePrereleases, boolean currentIsSnapshot, SemVer currentSemVer, int build) {
+        if (latest) {
+            return selectLatest(releases, includePrereleases);
         }
-        return selectCurrent(releases, currentSemVer, snapshot, build);
+        if (currentIsSnapshot) {
+            return selectLatest(releases, true); // rolling snapshot channel: no exact per-build release
+        }
+        return selectCurrent(releases, currentSemVer, false, build);
     }
 
-    /** Newest release of the matching type: stable-only for a release build, pre-releases too for a snapshot. */
-    static Version selectLatest(Version[] releases, boolean snapshot) {
+    /** Newest release, optionally including pre-releases (snapshots) rather than stable-only. */
+    static Version selectLatest(Version[] releases, boolean includePrereleases) {
         return StreamEx.of(releases)
                        .sorted(Comparator.comparing(Version::semVer).reversed())
-                       .filter(v -> snapshot || !v.prerelease())
+                       .filter(v -> includePrereleases || !v.prerelease())
                        .findFirst()
                        .orElse(null);
     }

--- a/src/main/java/com/getpcpanel/util/version/VersionChecker.java
+++ b/src/main/java/com/getpcpanel/util/version/VersionChecker.java
@@ -33,6 +33,7 @@ public class VersionChecker extends Thread {
     @Inject Event<Object> eventBus;
     @Inject SaveService save;
     @Inject ObjectMapper objectMapper;
+    @Inject AutoUpdateService autoUpdate;
 
     @ConfigProperty(name = "pcpanel.version")
     String version;
@@ -65,17 +66,37 @@ public class VersionChecker extends Thread {
 
             var correctVersion = getVersionOfCorrectType(versions);
             if (versionIsNewer(correctVersion)) {
-                eventBus.fire(new NewVersionAvailableEvent(correctVersion));
+                onNewVersion(correctVersion);
             }
         } catch (Exception e) {
             log.error("Unable to get latest version from GitHub", e);
         }
     }
 
+    /**
+     * A newer version of the chosen type is available. If auto-update is enabled and supported (a Windows
+     * install), download and silently install it now and let the installer restart the app; otherwise
+     * (or if the update could not be started) notify the UI so the user can update manually.
+     */
+    private void onNewVersion(Version correctVersion) {
+        if (save.get().isAutoUpdate() && autoUpdate.isSupported()) {
+            try {
+                log.info("Auto-updating to {} on startup", correctVersion.versionDisplay());
+                autoUpdate.updateToLatest();
+                return; // the installer closes and relaunches the app
+            } catch (Exception e) {
+                log.error("Auto-update on startup failed; falling back to a notification", e);
+            }
+        }
+        eventBus.fire(new NewVersionAvailableEvent(correctVersion));
+    }
+
+    // Whether to consider pre-release (snapshot) builds is now an explicit user setting, not derived from
+    // the running build's own snapshot-ness (currentIsSnapshot is only used to compare build numbers).
     private Version getVersionOfCorrectType(Version[] versions) {
         return StreamEx.of(versions)
                        .sorted(Comparator.comparing(Version::semVer).reversed())
-                       .filter(v -> currentIsSnapshot || !v.prerelease())
+                       .filter(v -> save.get().isCheckForPreReleases() || !v.prerelease())
                        .findFirst()
                        .orElseThrow(() -> new RuntimeException("Unable to find release"));
     }

--- a/src/main/webui/src/app/models/generated/backend.types.ts
+++ b/src/main/webui/src/app/models/generated/backend.types.ts
@@ -726,6 +726,8 @@ export interface SerialPortDto {
 }
 
 export interface SettingsDto {
+    autoUpdate: boolean;
+    checkForPreReleases: boolean;
     dblClickInterval: number;
     focusVolumeOverrides: FocusVolumeOverride[];
     forceVolume: boolean;

--- a/src/main/webui/src/app/pages/settings/settings.component.html
+++ b/src/main/webui/src/app/pages/settings/settings.component.html
@@ -69,6 +69,24 @@
               <pc-toggle [value]="s.startupVersionCheck" (valueChange)="patch('startupVersionCheck', $event)"></pc-toggle>
             </div>
             <div class="row">
+              <div class="row-text">
+                <div class="row-label">Check for pre-release versions</div>
+                <div class="row-sub">Also be notified about in-development snapshot builds, not just stable releases.</div>
+              </div>
+              <pc-toggle [value]="s.checkForPreReleases" [disabled]="!s.startupVersionCheck"
+                         (valueChange)="patch('checkForPreReleases', $event)"></pc-toggle>
+            </div>
+            @if (platform.autoUpdate()) {
+              <div class="row">
+                <div class="row-text">
+                  <div class="row-label">Automatically install updates</div>
+                  <div class="row-sub">On startup, download and install a newer version and restart — no clicking through the installer.</div>
+                </div>
+                <pc-toggle [value]="s.autoUpdate" [disabled]="!s.startupVersionCheck"
+                           (valueChange)="patch('autoUpdate', $event)"></pc-toggle>
+              </div>
+            }
+            <div class="row">
               <div class="row-text"><div class="row-label">Double-click interval</div><div class="row-sub">milliseconds</div></div>
               <div class="pc-field num-field">
                 <input class="pc-field-input" type="number" min="0" [value]="s.dblClickInterval ?? 0"

--- a/src/test/java/com/getpcpanel/util/version/AutoUpdateServiceTest.java
+++ b/src/test/java/com/getpcpanel/util/version/AutoUpdateServiceTest.java
@@ -36,8 +36,8 @@ class AutoUpdateServiceTest {
         // Running build 73 (newer than the published 71): reinstall-current must still resolve, to 71,
         // instead of demanding a non-existent "build 73" release.
         var current = SemVer.fromName("2.0-SNAPSHOT").withBuild(73);
-        assertEquals(2, AutoUpdateService.chooseTarget(releases, false, true, current, 73).id());
-        assertEquals(2, AutoUpdateService.chooseTarget(releases, true, true, current, 73).id());
+        assertEquals(2, AutoUpdateService.chooseTarget(releases, false, true, true, current, 73).id());
+        assertEquals(2, AutoUpdateService.chooseTarget(releases, true, true, true, current, 73).id());
     }
 
     @Test
@@ -46,9 +46,21 @@ class AutoUpdateServiceTest {
                 release(3, "v2.1", false),
                 release(2, "v2.0", false),
         };
-        assertEquals(2, AutoUpdateService.chooseTarget(releases, false, false, SemVer.fromName("2.0"), -1).id());
+        assertEquals(2, AutoUpdateService.chooseTarget(releases, false, false, false, SemVer.fromName("2.0"), -1).id());
         // ...but "update to latest" jumps to the newest stable.
-        assertEquals(3, AutoUpdateService.chooseTarget(releases, true, false, SemVer.fromName("2.0"), -1).id());
+        assertEquals(3, AutoUpdateService.chooseTarget(releases, true, false, false, SemVer.fromName("2.0"), -1).id());
+    }
+
+    @Test
+    void chooseTargetPreReleaseOptInControlsWhetherUpdatesSeeSnapshots() {
+        var releases = new Version[] {
+                release(3, "v2.1-SNAPSHOT Pre-Release (10)", true),
+                release(2, "v2.0", false),
+        };
+        // Opted in: update jumps to the newer pre-release.
+        assertEquals(3, AutoUpdateService.chooseTarget(releases, true, true, false, SemVer.fromName("2.0"), -1).id());
+        // Opted out: only stable is considered, so it stays on 2.0.
+        assertEquals(2, AutoUpdateService.chooseTarget(releases, true, false, false, SemVer.fromName("2.0"), -1).id());
     }
 
     @Test


### PR DESCRIPTION
Two new settings under "Check for updates on startup":

- **Check for pre-release versions** (all platforms) — explicit opt-in to snapshot/pre-release builds. The update *type* is no longer derived from whether the running build is a snapshot; that now only affects build-number comparison.
- **Automatically install updates** (Windows install only, off by default) — when a newer version of the chosen type is found on startup, `VersionChecker` downloads and silently installs it and the installer restarts the app, instead of only notifying.

Both are only meaningful when "Check for updates on startup" is on; the UI disables them otherwise, and the startup check (hence auto-update) only runs when it's on. `AutoUpdateService`'s "update to latest" honors the pre-release setting; "reinstall current" still keys off the running build's snapshot-ness (the rolling channel has no per-build release).

Backend compiles; 457 tests pass (incl. new pre-release opt-in cases). Frontend builds.

## AI-assisted contribution

This pull request was made by an AI without any human intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)