### PR TITLE
feat(linux): self-update for AppImage (zsync) and Flatpak (OSTree/Pages)

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -281,6 +281,13 @@ jobs:
           path: ~/.cache/pcpanel-kdotool
           key: kdotool-${{ hashFiles('packaging/linux/fetch-kdotool.sh') }}
 
+      # Downloaded once per pin, same pattern as kdotool (see fetch-appimageupdatetool.sh).
+      - name: Cache appimageupdatetool
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pcpanel-appimageupdatetool
+          key: appimageupdatetool-${{ hashFiles('packaging/linux/fetch-appimageupdatetool.sh') }}
+
       - name: Build .deb
         run: |
           exe=$(ls target/*-runner | head -1)
@@ -303,6 +310,17 @@ jobs:
           export APPIMAGETOOL="$PWD/appimagetool"
           export APPIMAGE_EXTRACT_AND_RUN=1   # CI runners have no FUSE
           export ARCH=x86_64
+          # Bake self-update info so the AppImage can update itself in place (zsync). It targets this
+          # branch's own rolling pre-release ("latest-<safe-branch>", the same tag preRelease publishes
+          # to), so an installed build self-updates to the newest build of the SAME branch — which is
+          # exactly what makes it testable by re-running this workflow. For a stable 2.0 release, swap the
+          # tag for the literal "latest" (GitHub's newest non-prerelease). appimagetool also emits
+          # PCPanel-*-x86_64.AppImage.zsync next to the output; preRelease uploads it alongside.
+          branch="${GITHUB_REF#refs/heads/}"
+          safe_branch=$(echo "$branch" | sed 's/[^A-Za-z0-9._-]/-/g')
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repo="${GITHUB_REPOSITORY#*/}"
+          export UPDATE_INFO="gh-releases-zsync|${owner}|${repo}|latest-${safe_branch}|PCPanel-*-x86_64.AppImage.zsync"
           exe=$(ls target/*-runner | head -1)
           bash packaging/linux/appimage/build-appimage.sh "${{ steps.ver.outputs.version }}" "$exe" target
 
@@ -317,7 +335,11 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: linux-appimage
-          path: ./target/*.AppImage
+          # The .zsync control file must ship next to the AppImage on the release, or the bundled
+          # appimageupdatetool cannot find what to pull.
+          path: |
+            ./target/*.AppImage
+            ./target/*.AppImage.zsync
           if-no-files-found: error
 
       # Hand the native binary + companion .so libraries to the buildFlatpak job, which runs inside
@@ -343,6 +365,9 @@ jobs:
     # Job-level continue-on-error: even a container-start failure (bad image, infra) must not fail the
     # run or block the release. preRelease gates only on the required Windows/Linux jobs (see its `if`).
     continue-on-error: true
+    # contents: write is for pushing the updated OSTree repo to the gh-pages branch (Flatpak updates).
+    permissions:
+      contents: write
     container:
       image: bilelmoussaoui/flatpak-github-actions:freedesktop-24.08
       options: --privileged
@@ -390,19 +415,78 @@ jobs:
           cp native/*.so "$stage/" 2>/dev/null || true
           tar -czf "$build/pcpanel-native.tar.gz" -C "$stage" .
 
-      - name: Build Flatpak bundle
+      # Build the Flatpak into a persistent OSTree repo (not just a one-shot bundle) so installs from the
+      # hosted repo can `flatpak update`. The repo lives on the gh-pages branch and carries exactly two
+      # rolling refs — `stable` (from releases/** branches) and `snapshot` (everything else) — each pruned
+      # to its single latest commit, so the published site stays small (GitHub Pages caps at ~1 GB). We
+      # clone the existing gh-pages repo first and build into it, so the *other* channel's ref survives
+      # this run. The single-file .flatpak bundle is still produced as a direct-download release asset.
+      - name: Build Flatpak (OSTree repo + bundle)
         id: flatpak
         continue-on-error: true
-        uses: flatpak/flatpak-github-actions/flatpak-builder@401fe28a8384095fc1531b9d320b292f0ee45adb # v6
-        with:
-          bundle: PCPanel-${{ steps.ver.outputs.version }}.flatpak
-          manifest-path: flatpak-build/com.getpcpanel.PCPanel.yml
-          cache-key: flatpak-builder-${{ github.sha }}
-          arch: x86_64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euxo pipefail
+          channel=snapshot
+          case "${GITHUB_REF#refs/heads/}" in releases/*) channel=stable;; esac
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+
+          # Start from the currently published repo so we don't drop the other channel's ref. A shallow
+          # clone still contains every file at HEAD (depth limits history, not content). First publish
+          # (no gh-pages yet) starts empty; flatpak-builder --repo initialises the OSTree repo.
+          git config --global --add safe.directory "$PWD"
+          if git clone --depth 1 --branch gh-pages \
+               "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" site 2>/dev/null; then
+            echo "Reusing existing gh-pages repo"
+          else
+            echo "No gh-pages yet; starting a fresh site"
+            mkdir -p site
+          fi
+          mkdir -p site/repo
+
+          # Unsigned repo (the .flatpakref carries no GPGKey); served over HTTPS from Pages.
+          flatpak-builder --user --disable-rofiles-fuse --force-clean \
+            --repo=site/repo --default-branch="$channel" \
+            builddir flatpak-build/com.getpcpanel.PCPanel.yml
+
+          flatpak build-bundle site/repo "PCPanel-${{ steps.ver.outputs.version }}.flatpak" \
+            com.getpcpanel.PCPanel "$channel"
+
+          # Keep only the newest commit per ref, then regenerate the summary/metadata.
+          ostree prune --repo=site/repo --refs-only --depth=0
+          flatpak build-update-repo --prune site/repo
+
+          # Static site: the .flatpakref install files, a landing page, and .nojekyll so GitHub Pages
+          # serves the OSTree object tree verbatim (Jekyll would drop files it considers special).
+          cp packaging/linux/flatpak/com.getpcpanel.PCPanel.stable.flatpakref   site/
+          cp packaging/linux/flatpak/com.getpcpanel.PCPanel.snapshot.flatpakref site/
+          touch site/.nojekyll
+          cat > site/index.html <<'HTML'
+          <!doctype html><meta charset=utf-8><title>PCPanel Flatpak</title>
+          <h1>PCPanel — Flatpak</h1>
+          <p>Install and then get automatic updates via your usual Flatpak tooling:</p>
+          <pre>flatpak install --user https://nvdweem.github.io/PCPanel/com.getpcpanel.PCPanel.stable.flatpakref</pre>
+          <p>Bleeding-edge builds (snapshot channel):</p>
+          <pre>flatpak install --user https://nvdweem.github.io/PCPanel/com.getpcpanel.PCPanel.snapshot.flatpakref</pre>
+          HTML
 
       - name: Report Flatpak result
         if: steps.flatpak.outcome != 'success'
-        run: echo "::warning::Flatpak bundle failed to build; releasing .deb + AppImage only."
+        run: echo "::warning::Flatpak build/publish failed; releasing .deb + AppImage only."
+
+      # Publish the merged repo to gh-pages. force_orphan keeps a single commit (the OSTree objects are
+      # large — history would balloon), which is safe because `site/` already contains the full merged
+      # repo. Only on the canonical repo, so forks don't try to push.
+      - name: Publish Flatpak repo to GitHub Pages
+        if: steps.flatpak.outcome == 'success' && github.repository == 'nvdweem/PCPanel'
+        continue-on-error: true
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages
+          force_orphan: true
 
       - name: Store Flatpak artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,23 +66,39 @@ install before running Maven, e.g. `export JAVA_HOME=~/.jdks/graalvm-ce-25.0.2`
 - **Run two instances side by side:** pass the `skipfilecheck` arg (otherwise launching a second
   instance just focuses the already-installed one — see `Main`/`FileChecker`). For a separate dev
   data dir, set `pcpanel.root=${user.home}/.pcpaneldev/` (dev profile already does this).
-- **Windows auto-update:** on an installed Windows build, `AutoUpdateService` (in `util/version/`)
-  downloads a GitHub release's `PCPanel-*-setup.exe` and runs it with `/VERYSILENT /SUPPRESSMSGBOXES
-  /NORESTART /UPDATE=1`. Inno keeps the existing install dir (fixed `AppId`); `TrayServiceWin` handles
-  the installer's `WM_CLOSE` to shut the running app down cleanly (releasing its file locks); the
-  installer's `pcpanel.iss` `/UPDATE`-gated `[Run]` entry relaunches it with `/updated` (the normal "Launch
-  now" entry is `skipifsilent` and wouldn't fire). `/updated` (handled in `Main` → `StartupOnboarding`)
-  flags the "just updated" dialog like `/postinstall` but does NOT open a browser — the UI that triggered
-  the update is already open; it re-fetches onboarding when its websocket reconnects and shows the dialog
-  itself (`OnboardingComponent`). Gated to `SystemUtils.IS_OS_WINDOWS &&`
-  native image, exposed to the UI as `PlatformInfo.autoUpdate`; elsewhere (Linux/macOS, dev/JVM) the
-  UI links to the release page instead. REST: `POST /api/system/update` (latest) and
-  `/api/system/update/reinstall` (the Debug page's reinstall-current button, for testing the flow).
-  Settings (`Save`): `autoUpdate` (Windows-only, off by default) makes `VersionChecker` install a newer
-  version on startup automatically instead of just notifying; `checkForPreReleases` is the explicit
-  opt-in to snapshot/pre-release builds — the "type" of update is no longer derived from whether the
-  running build is a snapshot (that only decides build-number comparison now). Both are only meaningful
-  when `startupVersionCheck` is on, and the UI disables them otherwise.
+- **Self-update (`util/version/`):** `AutoUpdateService` is a thin façade that picks the one
+  `PlatformUpdater` transport matching how the app is packaged (`isSupported()` is mutually exclusive) and
+  delegates. Exposed to the UI as `PlatformInfo.autoUpdate`; when no transport supports the install (a
+  `.deb`, dev/JVM, macOS) the UI links to the release page instead of offering "Update & restart". REST:
+  `POST /api/system/update` (latest) and `/api/system/update/reinstall` (the Debug page's
+  reinstall-current button — re-runs the real path against the current version to test the flow on any
+  platform, no newer release needed). The three transports:
+  - **Windows** (`WindowsInstallerUpdater`, installed native build): downloads a release's
+    `PCPanel-*-setup.exe` and runs it `/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /UPDATE=1`. Inno keeps the
+    existing install dir (fixed `AppId`); `TrayServiceWin` handles the installer's `WM_CLOSE` to shut the
+    app down cleanly; `pcpanel.iss`'s `/UPDATE`-gated `[Run]` entry relaunches it with `/updated` (the
+    normal "Launch now" entry is `skipifsilent`). `/updated` (`Main` → `StartupOnboarding`) flags the
+    "just updated" dialog like `/postinstall` but opens no browser (the triggering UI is already open).
+  - **AppImage** (`AppImageUpdater`, `$APPIMAGE` set): runs the bundled `appimageupdatetool -O -r
+    "$APPIMAGE"` (zsync delta, in place) then relaunches via `UpdaterRestart`. The AppImage carries
+    `gh-releases-zsync` update-info baked at build time (`appimagetool -u`, targeting the branch's rolling
+    `latest-<branch>` tag) and the companion `.zsync` is uploaded next to it. `packaging/linux/fetch-appimageupdatetool.sh`
+    pins the tool (MIT) by sha256, same model as kdotool.
+  - **Flatpak** (`FlatpakUpdater`, `$FLATPAK_ID` set): `flatpak-spawn --host flatpak update` then relaunch
+    on the host. Updates only work for installs from the hosted OSTree repo (the `.flatpakref` adds the
+    remote); the one-shot `.flatpak` bundle has none. CI publishes that repo to the **gh-pages** branch /
+    GitHub Pages with exactly two rolling refs — `stable` (from `releases/**`) and `snapshot` — each
+    pruned to its latest commit to stay under the ~1 GB Pages limit; each run clones the existing repo
+    first so the other channel's ref survives.
+
+  `UpdaterRestart` (Linux) starts a detached, self-delaying relauncher and then `Quarkus.asyncExit` — the
+  sleep lets the HTTP response flush and the single-instance `FileChecker` lock release before the new
+  process starts (the Flatpak relauncher is host-spawned so it survives the sandbox teardown).
+  Settings (`Save`): `autoUpdate` (off by default) makes `VersionChecker` install on startup instead of
+  only notifying, whenever a transport is supported; `checkForPreReleases` is the explicit opt-in to
+  snapshot/pre-release builds (the "type" of update is not derived from the running build's snapshot-ness
+  — that only decides build-number comparison). Both need `startupVersionCheck` on, and the UI disables
+  them otherwise.
 
 ### Frontend (`src/main/webui`, Angular 21)
 

--- a/linux.md
+++ b/linux.md
@@ -76,13 +76,22 @@ executable, so it works without a system install. `xdotool` is only *suggested* 
 
 ### Flatpak (best-effort)
 
-A Flatpak bundle is provided as an alternative. Note that the app is primarily developed for Windows and the Flatpak sandbox
+A Flatpak is provided as an alternative. Note that the app is primarily developed for Windows and the Flatpak sandbox
 makes some features harder; it is provided on a best-effort basis.
 
+Install from the hosted repo so you get automatic updates (see [Updating](#updating)):
+
    ```shell
-   flatpak install --user PCPanel-[version].flatpak
+   # Stable channel (recommended):
+   flatpak install --user https://nvdweem.github.io/PCPanel/com.getpcpanel.PCPanel.stable.flatpakref
+   # …or the rolling snapshot channel:
+   flatpak install --user https://nvdweem.github.io/PCPanel/com.getpcpanel.PCPanel.snapshot.flatpakref
    flatpak run com.getpcpanel.PCPanel
    ```
+
+The single-file `PCPanel-[version].flatpak` bundle attached to each release is also available
+(`flatpak install --user PCPanel-[version].flatpak`), but a bundle install has no remote attached, so it
+will **not** receive updates — prefer the `.flatpakref` above unless you have a reason not to.
 
 > **Device access:** the Flatpak still needs the host udev rule from [Preparation](#preparation) above — the sandbox can see
 > the device but cannot grant itself permission to open it. If the device is detected but never connects (`Unable to open
@@ -102,6 +111,24 @@ Plasma focus volume works without a host-installed kdotool. Volume control (`pac
 
 If neither package works on your distribution, download the raw executable from the release (it sits inside the `.deb`
 under `/opt/pcpanel`) together with its `.so` libraries and run `./PCPanel`.
+
+## Updating
+
+The app checks GitHub for newer releases on startup (toggle under Settings → Updates) and shows a popup when
+one is available. Whether the popup can update in place depends on how you installed:
+
+- **AppImage** — self-updating. The popup's **Update & restart** button (or Settings → Auto-update → *Reinstall*
+  to test the flow) runs the bundled `appimageupdatetool`, which pulls only the changed blocks (zsync) into the
+  same `.AppImage` file and relaunches. Requires that you launched the actual `.AppImage` (the runtime sets
+  `$APPIMAGE`); running an extracted copy falls back to the download link. You can also update by hand:
+  `appimageupdatetool PCPanel-*.AppImage`.
+- **Flatpak** — self-updating **when installed from the `.flatpakref`** (which adds the hosted remote). **Update &
+  restart** runs `flatpak update` on the host and relaunches; your desktop's software centre (GNOME Software / KDE
+  Discover) also updates it automatically in the background. An install from the one-shot `.flatpak` bundle has no
+  remote and cannot update — reinstall from the `.flatpakref` to switch.
+- **`.deb`** — updated through your package manager as usual; the popup links to the download page (no in-app update).
+
+Stable installs follow the stable releases; snapshot/`snapshot`-channel installs follow the rolling pre-releases.
 
 ## Settings and data location
 

--- a/packaging/linux/appimage/build-appimage.sh
+++ b/packaging/linux/appimage/build-appimage.sh
@@ -17,6 +17,10 @@
 # Environment:
 #   APPIMAGETOOL  - path to appimagetool (default: "appimagetool" on PATH)
 #   ARCH          - target arch for appimagetool (default: x86_64)
+#   UPDATE_INFO   - AppImage update-information string baked into the output so it can self-update, e.g.
+#                   "gh-releases-zsync|<owner>|<repo>|<tag>|PCPanel-*-x86_64.AppImage.zsync". When set,
+#                   appimagetool also emits <output>.zsync, which MUST be uploaded to the release next to
+#                   the AppImage. Unset (local builds) → no update info, no .zsync, no self-update.
 set -euo pipefail
 
 VERSION="${1:?usage: build-appimage.sh <version> <native-exe> <output-dir>}"
@@ -56,6 +60,12 @@ shopt -u nullglob
 bash "$PKG_LINUX/fetch-kdotool.sh" "$APPDIR/usr/bin" || \
     echo ">> WARNING: could not bundle kdotool; focus volume will need a system kdotool/xdotool" >&2
 
+# Bundle appimageupdatetool next to the executable so the app can update itself in place (zsync). It reads
+# the update-information baked in below via UPDATE_INFO; AppImageUpdater runs the sibling tool. Only useful
+# when UPDATE_INFO is set, but harmless to bundle either way. No-op on non-x86_64 (no upstream binary).
+bash "$PKG_LINUX/fetch-appimageupdatetool.sh" "$APPDIR/usr/bin" || \
+    echo ">> WARNING: could not bundle appimageupdatetool; AppImage self-update will be unavailable" >&2
+
 # AppRun launcher.
 install -m 0755 "$PKG_LINUX/appimage/AppRun" "$APPDIR/AppRun"
 
@@ -73,5 +83,13 @@ OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 OUT="$OUTPUT_DIR/PCPanel-${VERSION}-${ARCH}.AppImage"
 
 echo ">> Building AppImage with $APPIMAGETOOL"
-"$APPIMAGETOOL" "$APPDIR" "$OUT"
+if [ -n "${UPDATE_INFO:-}" ]; then
+    # -u bakes the update-information into the AppImage and makes appimagetool emit "$OUT.zsync"
+    # alongside it (the control file the updater fetches). Both must be uploaded to the release.
+    echo ">> Embedding update information: $UPDATE_INFO"
+    "$APPIMAGETOOL" -u "$UPDATE_INFO" "$APPDIR" "$OUT"
+else
+    echo ">> No UPDATE_INFO set; building without self-update information"
+    "$APPIMAGETOOL" "$APPDIR" "$OUT"
+fi
 echo ">> Built $OUT"

--- a/packaging/linux/fetch-appimageupdatetool.sh
+++ b/packaging/linux/fetch-appimageupdatetool.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Fetch appimageupdatetool (MIT, AppImageCommunity/AppImageUpdate) that the PCPanel AppImage bundles so
+# it can update itself in place.
+#
+# It reads the zsync update-information baked into our AppImage (appimagetool -u ...), downloads only the
+# changed blocks from the release that info points at, and atomically replaces the file. AppImageUpdater
+# runs it as: `appimageupdatetool -O -r "$APPIMAGE"` with APPIMAGE_EXTRACT_AND_RUN=1 (no FUSE needed on
+# the user's machine, since the tool is itself an AppImage).
+#
+# Pinned to a known release + sha256 for reproducible, verifiable builds. To update, bump AUT_VERSION and
+# AUT_SHA256 together (fetch the asset and `sha256sum` it).
+#
+# Usage:
+#   packaging/linux/fetch-appimageupdatetool.sh <dest-dir>
+# Installs <dest-dir>/appimageupdatetool-x86_64.AppImage (executable) — the name AppImageUpdater looks for
+# next to the PCPanel binary.
+#
+# Caching: mirrors fetch-kdotool.sh — the asset is cached under
+# ${AUT_CACHE_DIR:-$HOME/.cache/pcpanel-appimageupdatetool} and reused (sha256-verified) on later runs. In
+# CI, wrap that dir with actions/cache keyed on this script's hash so it downloads once per pin.
+#
+# Only x86_64 has an upstream prebuilt binary. On any other arch this is a no-op (exit 0): the AppImage
+# then has no bundled updater and AppImageUpdater.isSupported() is false, so the UI falls back to the
+# download link.
+set -euo pipefail
+
+AUT_VERSION="2.0.0-alpha-1-20251018"
+AUT_SHA256="d976cdac667b03dee8cb23fb95ef74b042c406c5cbab3ff294d2b16efeaff84f"
+ARCH="${ARCH:-$(uname -m)}"
+
+DEST_DIR="${1:?usage: fetch-appimageupdatetool.sh <dest-dir>}"
+
+if [ "$ARCH" != "x86_64" ]; then
+    echo ">> appimageupdatetool: no upstream prebuilt binary for arch '$ARCH'; skipping bundle." >&2
+    exit 0
+fi
+
+asset="appimageupdatetool-x86_64.AppImage"
+url="https://github.com/AppImageCommunity/AppImageUpdate/releases/download/${AUT_VERSION}/${asset}"
+cache_dir="${AUT_CACHE_DIR:-$HOME/.cache/pcpanel-appimageupdatetool}"
+cached="${cache_dir}/${asset}-${AUT_VERSION}"
+
+mkdir -p "$cache_dir"
+
+verify() { echo "${AUT_SHA256}  $1" | sha256sum -c - >/dev/null 2>&1; }
+
+if [ -f "$cached" ] && verify "$cached"; then
+    echo ">> appimageupdatetool ${AUT_VERSION}: using cached asset"
+else
+    echo ">> appimageupdatetool ${AUT_VERSION}: downloading $url"
+    curl -fsSL --retry 3 -o "${cached}.tmp" "$url"
+    if ! verify "${cached}.tmp"; then
+        echo "error: sha256 mismatch for ${asset} (expected ${AUT_SHA256})" >&2
+        rm -f "${cached}.tmp"
+        exit 1
+    fi
+    mv "${cached}.tmp" "$cached"
+fi
+
+mkdir -p "$DEST_DIR"
+install -m 0755 "$cached" "$DEST_DIR/${asset}"
+echo ">> appimageupdatetool ${AUT_VERSION} installed to ${DEST_DIR}/${asset}"

--- a/packaging/linux/flatpak/com.getpcpanel.PCPanel.snapshot.flatpakref
+++ b/packaging/linux/flatpak/com.getpcpanel.PCPanel.snapshot.flatpakref
@@ -1,0 +1,9 @@
+[Flatpak Ref]
+Title=PCPanel (snapshot)
+Name=com.getpcpanel.PCPanel
+Branch=snapshot
+Url=https://nvdweem.github.io/PCPanel/repo
+Homepage=https://github.com/nvdweem/PCPanel
+Comment=Community controller software for PCPanel USB audio devices (rolling snapshot channel)
+IsRuntime=false
+RuntimeRepo=https://flathub.org/repo/flathub.flatpakref

--- a/packaging/linux/flatpak/com.getpcpanel.PCPanel.stable.flatpakref
+++ b/packaging/linux/flatpak/com.getpcpanel.PCPanel.stable.flatpakref
@@ -1,0 +1,9 @@
+[Flatpak Ref]
+Title=PCPanel
+Name=com.getpcpanel.PCPanel
+Branch=stable
+Url=https://nvdweem.github.io/PCPanel/repo
+Homepage=https://github.com/nvdweem/PCPanel
+Comment=Community controller software for PCPanel USB audio devices (stable channel)
+IsRuntime=false
+RuntimeRepo=https://flathub.org/repo/flathub.flatpakref

--- a/src/main/java/com/getpcpanel/util/version/AppImageUpdater.java
+++ b/src/main/java/com/getpcpanel/util/version/AppImageUpdater.java
@@ -53,7 +53,9 @@ public class AppImageUpdater implements PlatformUpdater {
         }
 
         log.info("Updating AppImage {} via {}", appImage, tool);
-        var pb = new ProcessBuilder(tool, appImage);
+        // -O overwrites the AppImage in place (the default writes a new file and leaves ours untouched);
+        // -r removes the .zs-old backup once the new file verifies.
+        var pb = new ProcessBuilder(tool, "-O", "-r", appImage);
         pb.environment().put("APPIMAGE_EXTRACT_AND_RUN", "1");
         pb.redirectOutput(ProcessBuilder.Redirect.DISCARD).redirectError(ProcessBuilder.Redirect.DISCARD);
         var code = pb.start().waitFor();

--- a/src/main/java/com/getpcpanel/util/version/AppImageUpdater.java
+++ b/src/main/java/com/getpcpanel/util/version/AppImageUpdater.java
@@ -1,0 +1,78 @@
+package com.getpcpanel.util.version;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Linux AppImage self-update. Runs the bundled {@code appimageupdatetool} against our own
+ * {@code $APPIMAGE}; it reads the zsync update-information baked into the AppImage at build time, pulls
+ * only the changed blocks from the release it points at, atomically replaces the file (keeping a
+ * {@code .zs-old} backup), and we then relaunch the updated file.
+ *
+ * <p>Supported only when running as an AppImage — the runtime exports {@code $APPIMAGE} as the absolute
+ * path of the outer {@code .AppImage} — and only when {@code appimageupdatetool} is bundled next to our
+ * binary (the {@code .deb}/dev runs are not AppImages, so they fall back to the download link).
+ * {@code reinstallCurrent()} runs the exact same path so the mechanism can be smoke-tested from the debug
+ * page without a newer release existing (zsync finds every block locally and just re-validates + relaunches).
+ */
+@Log4j2
+@ApplicationScoped
+public class AppImageUpdater implements PlatformUpdater {
+    // appimageupdatetool is itself distributed as an AppImage; bundled next to our binary and run with
+    // APPIMAGE_EXTRACT_AND_RUN so it needs no FUSE on the user's machine.
+    private static final String TOOL = "appimageupdatetool-x86_64.AppImage";
+
+    @Override
+    public boolean isSupported() {
+        var appImage = System.getenv("APPIMAGE");
+        return StringUtils.isNotBlank(appImage) && Files.isRegularFile(Path.of(appImage)) && tool() != null;
+    }
+
+    @Override
+    public AutoUpdateService.UpdateTarget updateToLatest() throws Exception {
+        return runUpdate();
+    }
+
+    @Override
+    public AutoUpdateService.UpdateTarget reinstallCurrent() throws Exception {
+        return runUpdate();
+    }
+
+    private AutoUpdateService.UpdateTarget runUpdate() throws Exception {
+        var appImage = System.getenv("APPIMAGE");
+        var tool = tool();
+        if (StringUtils.isBlank(appImage) || tool == null) {
+            throw new AutoUpdateService.UpdateException("AppImage self-update is only available when running as an AppImage.");
+        }
+
+        log.info("Updating AppImage {} via {}", appImage, tool);
+        var pb = new ProcessBuilder(tool, appImage);
+        pb.environment().put("APPIMAGE_EXTRACT_AND_RUN", "1");
+        pb.redirectOutput(ProcessBuilder.Redirect.DISCARD).redirectError(ProcessBuilder.Redirect.DISCARD);
+        var code = pb.start().waitFor();
+        if (code != 0) {
+            throw new AutoUpdateService.UpdateException("The AppImage updater exited with code " + code + ".");
+        }
+
+        // sh -c 'sleep 3; exec "$0"' <appimage> — $0 is the updated file; exec replaces the shell with it.
+        UpdaterRestart.relaunchAndExit(List.of("sh", "-c", "sleep 3; exec \"$0\"", appImage));
+        return new AutoUpdateService.UpdateTarget("the latest version", "");
+    }
+
+    /** The bundled appimageupdatetool next to our own executable, or null when it is not present. */
+    private static String tool() {
+        return ProcessHandle.current().info().command()
+                            .map(Path::of).map(Path::getParent).filter(Objects::nonNull)
+                            .map(dir -> dir.resolve(TOOL))
+                            .filter(Files::isExecutable)
+                            .map(Path::toString)
+                            .orElse(null);
+    }
+}

--- a/src/main/java/com/getpcpanel/util/version/AutoUpdateService.java
+++ b/src/main/java/com/getpcpanel/util/version/AutoUpdateService.java
@@ -1,228 +1,60 @@
 package com.getpcpanel.util.version;
 
-import static com.getpcpanel.util.version.Version.SNAPSHOT_POSTFIX;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import java.util.Comparator;
-import java.util.regex.Pattern;
-
-import org.apache.commons.lang3.SystemUtils;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.getpcpanel.util.SharedHttpClient;
-import com.getpcpanel.util.version.Version.SemVer;
-
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import lombok.extern.log4j.Log4j2;
-import one.util.streamex.StreamEx;
 
 /**
- * Windows self-update: downloads a GitHub release's Inno Setup installer and runs it silently, so the
- * user gets a one-click "Update &amp; restart" instead of downloading and clicking through the installer
- * by hand.
- *
- * <p>Only supported on a Windows <em>installed</em> build (native image). Elsewhere — Linux/macOS, or a
- * dev/JVM run on Windows — {@link #isSupported()} is false and the UI keeps linking to the release
- * download page instead. The install itself is unattended: the installer keeps the existing install
- * directory (its {@code AppId} matches), {@code TrayServiceWin} closes the running app on the installer's
- * {@code WM_CLOSE}, and the installer relaunches it via its {@code /UPDATE} {@code [Run]} entry (see
- * {@code packaging/windows/pcpanel.iss}).
+ * Self-update façade. Everything that drives updates (the REST {@code SystemResource}, the startup
+ * {@link VersionChecker}, and {@code PlatformResource} for the UI capability flag) injects this bean. It
+ * picks the one {@link PlatformUpdater} transport that matches how the app is packaged and delegates to
+ * it:
+ * <ul>
+ *   <li>{@link WindowsInstallerUpdater} — Windows Inno Setup installer, downloaded and run silently.</li>
+ *   <li>{@link AppImageUpdater} — Linux AppImage, updated in place via zsync.</li>
+ *   <li>{@link FlatpakUpdater} — Linux Flatpak, updated from its OSTree remote.</li>
+ * </ul>
+ * When no transport supports the running install — a Linux {@code .deb}, a dev/JVM run, or macOS —
+ * {@link #isSupported()} is false and the UI keeps linking to the release download page instead of
+ * offering a one-click "Update &amp; restart".
  */
 @Log4j2
 @ApplicationScoped
 public class AutoUpdateService {
-    // Inno Setup silent-install switches: no UI, no message boxes, don't reboot. /UPDATE=1 is our own
-    // switch that tells the script to relaunch the app after a silent update (its [Run] "Launch now"
-    // entry is skipifsilent and would otherwise not fire).
-    private static final String[] SILENT_INSTALL_ARGS = { "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/UPDATE=1" };
-    // The Windows installer asset produced by CI is named "PCPanel-<version>-setup.exe".
-    static final Pattern SETUP_ASSET = Pattern.compile("(?i)^pcpanel-.*setup\\.exe$");
+    @Inject Instance<PlatformUpdater> updaters;
 
-    @Inject ObjectMapper objectMapper;
-    @Inject com.getpcpanel.profile.SaveService save;
+    /** The single transport that supports the running install, or null when none does. */
+    private PlatformUpdater active() {
+        return updaters.stream().filter(PlatformUpdater::isSupported).findFirst().orElse(null);
+    }
 
-    @ConfigProperty(name = "pcpanel.github.user-and-repo") String githubUserAndRepo;
-    @ConfigProperty(name = "pcpanel.version") String version;
-    @ConfigProperty(name = "pcpanel.build") int build;
-
-    /** True only where an unattended installer update can run: a Windows native-image install. */
+    /** True when an in-place update can run for this install (Windows installer, AppImage, or Flatpak). */
     public boolean isSupported() {
-        return SystemUtils.IS_OS_WINDOWS && isNativeImage();
+        return active() != null;
     }
 
-    /** Download and silently install the newest available release, then restart. */
-    public UpdateTarget updateToLatest() throws IOException, InterruptedException {
-        return performUpdate(resolveTarget(true));
+    /** Update to the newest available release, then restart. */
+    public UpdateTarget updateToLatest() throws Exception {
+        return require().updateToLatest();
     }
 
-    /**
-     * Debug/testing: re-download and reinstall the <em>currently running</em> version through the exact
-     * same path, so the update mechanism can be exercised without waiting for a newer release.
-     */
-    public UpdateTarget reinstallCurrent() throws IOException, InterruptedException {
-        return performUpdate(resolveTarget(false));
+    /** Debug/testing: re-run the update path against the currently running version, to exercise it. */
+    public UpdateTarget reinstallCurrent() throws Exception {
+        return require().reinstallCurrent();
     }
 
-    /** The release we are about to install: its display version and the installer download URL. */
+    private PlatformUpdater require() {
+        var active = active();
+        if (active == null) {
+            throw new UpdateException("Automatic updates are not available for this installation.");
+        }
+        return active;
+    }
+
+    /** The release we are about to install: its display version and (Windows only) the installer URL. */
     @io.quarkus.runtime.annotations.RegisterForReflection
     public record UpdateTarget(String version, String installerUrl) {}
-
-    /**
-     * Pick the release to install and its Windows installer asset. {@code latest=true} chooses the newest
-     * release of the matching type (stable for a release build, including pre-releases for a snapshot);
-     * {@code latest=false} chooses the release that matches the currently running version.
-     */
-    private UpdateTarget resolveTarget(boolean latest) throws IOException, InterruptedException {
-        if (!isSupported()) {
-            throw new UpdateException("Automatic updates are only available on an installed Windows build.");
-        }
-
-        var url = "https://api.github.com/repos/" + githubUserAndRepo + "/releases?per_page=20";
-        var request = HttpRequest.newBuilder(URI.create(url)).header("Accept", "application/vnd.github+json").build();
-        var response = SharedHttpClient.get().send(request, HttpResponse.BodyHandlers.ofString());
-        if (response.statusCode() / 100 != 2) {
-            throw new UpdateException("GitHub returned HTTP " + response.statusCode() + " while looking for the installer.");
-        }
-
-        var root = objectMapper.readTree(response.body());
-        var releases = objectMapper.treeToValue(root, Version[].class);
-        var target = chooseTarget(releases, latest, save.get().isCheckForPreReleases(), isSnapshot(), currentSemVer(), build);
-        if (target == null) {
-            throw new UpdateException(latest
-                    ? "No suitable release was found to update to."
-                    : "Could not find a release matching the running version (" + versionDisplay() + ") to reinstall.");
-        }
-
-        var installerUrl = findInstallerAsset(root, target.id());
-        if (installerUrl == null) {
-            throw new UpdateException("Release " + target.versionDisplay() + " has no Windows installer to download.");
-        }
-        return new UpdateTarget(target.versionDisplay(), installerUrl);
-    }
-
-    /**
-     * Pick the release to install.
-     * <ul>
-     *   <li>{@code latest} — update to the newest available, filtered by {@code includePrereleases} (the
-     *       user's "check for pre-release versions" choice).</li>
-     *   <li>otherwise — reinstall the current version. A {@code currentIsSnapshot} build has no per-build
-     *       release to match (all snapshots share the rolling {@code latest-main} pre-release), so it
-     *       targets the newest pre-release; a release build matches its exact named release.</li>
-     * </ul>
-     */
-    static Version chooseTarget(Version[] releases, boolean latest, boolean includePrereleases, boolean currentIsSnapshot, SemVer currentSemVer, int build) {
-        if (latest) {
-            return selectLatest(releases, includePrereleases);
-        }
-        if (currentIsSnapshot) {
-            return selectLatest(releases, true); // rolling snapshot channel: no exact per-build release
-        }
-        return selectCurrent(releases, currentSemVer, false, build);
-    }
-
-    /** Newest release, optionally including pre-releases (snapshots) rather than stable-only. */
-    static Version selectLatest(Version[] releases, boolean includePrereleases) {
-        return StreamEx.of(releases)
-                       .sorted(Comparator.comparing(Version::semVer).reversed())
-                       .filter(v -> includePrereleases || !v.prerelease())
-                       .findFirst()
-                       .orElse(null);
-    }
-
-    /** The release matching the running version (same semver, and same build number for a snapshot). */
-    static Version selectCurrent(Version[] releases, SemVer currentSemVer, boolean snapshot, int build) {
-        return StreamEx.of(releases)
-                       .filter(v -> v.semVer().compareTo(currentSemVer) == 0 && (!snapshot || v.getBuild() == build))
-                       .findFirst()
-                       .orElse(null);
-    }
-
-    /** The {@code browser_download_url} of the setup asset in the release with the given id, or null. */
-    private String findInstallerAsset(JsonNode releasesRoot, int releaseId) {
-        for (var release : releasesRoot) {
-            if (release.path("id").asInt() != releaseId) {
-                continue;
-            }
-            for (var asset : release.path("assets")) {
-                var name = asset.path("name").asText("");
-                if (SETUP_ASSET.matcher(name).matches()) {
-                    return asset.path("browser_download_url").asText(null);
-                }
-            }
-        }
-        return null;
-    }
-
-    private UpdateTarget performUpdate(UpdateTarget target) throws IOException, InterruptedException {
-        var installer = downloadInstaller(URI.create(target.installerUrl()));
-        log.info("Update {} downloaded to {}; launching the silent installer", target.version(), installer);
-
-        var command = StreamEx.of(installer.toString()).append(SILENT_INSTALL_ARGS).toList();
-        // Start detached: the installer must outlive this process, which it closes (WM_CLOSE) and then
-        // relaunches. We do not wait for it.
-        new ProcessBuilder(command)
-                .directory(installer.getParent().toFile())
-                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
-                .redirectError(ProcessBuilder.Redirect.DISCARD)
-                .start();
-        return target;
-    }
-
-    private Path downloadInstaller(URI installerUrl) throws IOException, InterruptedException {
-        // Not deleteOnExit: the installer runs from this file and we exit moments later (it closes us), so
-        // deleting it on shutdown could race the installer still reading it. The OS cleans %TEMP% instead.
-        var dir = Files.createTempDirectory("pcpanel-update-");
-        var fileName = installerName(installerUrl);
-        var target = dir.resolve(fileName);
-
-        // GitHub asset URLs redirect to a CDN, so this client must follow redirects (the shared client
-        // does not). Built lazily here rather than as a static field to keep it out of the native-image
-        // build heap.
-        var client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
-        var request = HttpRequest.newBuilder(installerUrl).build();
-        var response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
-        if (response.statusCode() / 100 != 2) {
-            throw new UpdateException("Downloading the installer failed with HTTP " + response.statusCode() + ".");
-        }
-        try (var in = response.body()) {
-            Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
-        }
-        return target;
-    }
-
-    private static String installerName(URI installerUrl) {
-        var path = installerUrl.getPath();
-        var name = path.substring(path.lastIndexOf('/') + 1);
-        return name.toLowerCase().endsWith(".exe") ? name : "PCPanel-setup.exe";
-    }
-
-    private SemVer currentSemVer() {
-        var semVer = SemVer.fromName(version);
-        return isSnapshot() ? semVer.withBuild(build) : semVer;
-    }
-
-    private boolean isSnapshot() {
-        return version.endsWith(SNAPSHOT_POSTFIX);
-    }
-
-    private String versionDisplay() {
-        return isSnapshot() ? version + " (" + build + ")" : version;
-    }
-
-    @SuppressWarnings("AccessOfSystemProperties")
-    private static boolean isNativeImage() {
-        return "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
-    }
 
     /** A user-facing update failure; its message is surfaced to the UI. */
     public static class UpdateException extends RuntimeException {

--- a/src/main/java/com/getpcpanel/util/version/FlatpakUpdater.java
+++ b/src/main/java/com/getpcpanel/util/version/FlatpakUpdater.java
@@ -1,0 +1,57 @@
+package com.getpcpanel.util.version;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Linux Flatpak self-update. Asks the host (via {@code flatpak-spawn --host}) to {@code flatpak update}
+ * our own app id, which pulls the newest commit from the OSTree remote that the {@code .flatpakref} added
+ * at install time, then relaunches on the host.
+ *
+ * <p>Supported whenever running inside the Flatpak sandbox ({@code $FLATPAK_ID} is set). An install from
+ * the single-file {@code .flatpak} bundle has no remote, so {@code flatpak update} is simply a no-op there
+ * — the update only does something for installs that came from the hosted repo via the {@code .flatpakref}.
+ * {@code reinstallCurrent()} runs the same path (a no-op when already current) to smoke-test the wiring.
+ */
+@Log4j2
+@ApplicationScoped
+public class FlatpakUpdater implements PlatformUpdater {
+    @Override
+    public boolean isSupported() {
+        return StringUtils.isNotBlank(System.getenv("FLATPAK_ID"));
+    }
+
+    @Override
+    public AutoUpdateService.UpdateTarget updateToLatest() throws Exception {
+        return runUpdate();
+    }
+
+    @Override
+    public AutoUpdateService.UpdateTarget reinstallCurrent() throws Exception {
+        return runUpdate();
+    }
+
+    private AutoUpdateService.UpdateTarget runUpdate() throws Exception {
+        var appId = System.getenv("FLATPAK_ID");
+        if (StringUtils.isBlank(appId)) {
+            throw new AutoUpdateService.UpdateException("Flatpak self-update is only available inside the Flatpak sandbox.");
+        }
+
+        log.info("Updating Flatpak {} via the host", appId);
+        var code = new ProcessBuilder("flatpak-spawn", "--host", "flatpak", "update", "-y", appId)
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start().waitFor();
+        if (code != 0) {
+            throw new AutoUpdateService.UpdateException("flatpak update exited with code " + code + ".");
+        }
+
+        // Relaunch on the host so it survives the sandbox teardown when this instance exits.
+        UpdaterRestart.relaunchAndExit(List.of("flatpak-spawn", "--host", "sh", "-c", "sleep 3; flatpak run \"$0\"", appId));
+        return new AutoUpdateService.UpdateTarget("the latest version", "");
+    }
+}

--- a/src/main/java/com/getpcpanel/util/version/PlatformUpdater.java
+++ b/src/main/java/com/getpcpanel/util/version/PlatformUpdater.java
@@ -1,0 +1,22 @@
+package com.getpcpanel.util.version;
+
+/**
+ * One platform's self-update transport, selected at runtime by {@link AutoUpdateService} from the way the
+ * app is packaged: the Windows Inno Setup installer, a Linux AppImage (zsync), or a Linux Flatpak
+ * (OSTree). At most one is {@link #isSupported()} in a given process; the others report false and are
+ * never chosen. Implementations are {@code @ApplicationScoped} beans discovered via
+ * {@code Instance<PlatformUpdater>}.
+ */
+public interface PlatformUpdater {
+    /** True when this transport can perform an in-place update for the running install. */
+    boolean isSupported();
+
+    /** Update to the newest available release of the running channel, then restart. */
+    AutoUpdateService.UpdateTarget updateToLatest() throws Exception;
+
+    /**
+     * Debug/testing: re-run the update path against the current version, so the mechanism can be exercised
+     * without waiting for a newer release.
+     */
+    AutoUpdateService.UpdateTarget reinstallCurrent() throws Exception;
+}

--- a/src/main/java/com/getpcpanel/util/version/UpdaterRestart.java
+++ b/src/main/java/com/getpcpanel/util/version/UpdaterRestart.java
@@ -1,0 +1,48 @@
+package com.getpcpanel.util.version;
+
+import java.util.List;
+
+import io.quarkus.runtime.Quarkus;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Relaunch the app after a Linux in-place update. Unlike the Windows installer — which closes and
+ * relaunches the app itself — the AppImage/Flatpak transports update the files but leave the running
+ * process alone, so we must restart ourselves.
+ *
+ * <p>The recipe: start a small <em>detached</em> relauncher that sleeps a few seconds and then launches
+ * the (now updated) app, then ask Quarkus to shut down after a short grace period. The sleep lets this
+ * instance flush its HTTP response and release its single-instance lock ({@code FileChecker}) before the
+ * new one starts, so the relaunch is not swallowed by the "focus the existing instance" path.
+ */
+@Log4j2
+final class UpdaterRestart {
+    private UpdaterRestart() {}
+
+    /**
+     * @param relauncher a fully-formed, self-delaying command (it must outlive this process). For an
+     *                   AppImage this is a plain {@code sh -c 'sleep …; exec …'}; for a Flatpak it must be
+     *                   host-spawned ({@code flatpak-spawn --host …}) so it survives the sandbox teardown.
+     */
+    static void relaunchAndExit(List<String> relauncher) {
+        try {
+            new ProcessBuilder(relauncher)
+                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    .redirectError(ProcessBuilder.Redirect.DISCARD)
+                    .start();
+        } catch (Exception e) {
+            log.error("Could not schedule the post-update relaunch; the app will exit without restarting", e);
+        }
+
+        var exit = new Thread(() -> {
+            try {
+                Thread.sleep(1500); // let the REST response flush before tearing down
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+            Quarkus.asyncExit(0);
+        }, "post-update-exit");
+        exit.setDaemon(true);
+        exit.start();
+    }
+}

--- a/src/main/java/com/getpcpanel/util/version/WindowsInstallerUpdater.java
+++ b/src/main/java/com/getpcpanel/util/version/WindowsInstallerUpdater.java
@@ -1,0 +1,224 @@
+package com.getpcpanel.util.version;
+
+import static com.getpcpanel.util.version.Version.SNAPSHOT_POSTFIX;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.getpcpanel.util.SharedHttpClient;
+import com.getpcpanel.util.version.Version.SemVer;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.extern.log4j.Log4j2;
+import one.util.streamex.StreamEx;
+
+/**
+ * Windows self-update: downloads a GitHub release's Inno Setup installer and runs it silently, so the
+ * user gets a one-click "Update &amp; restart" instead of downloading and clicking through the installer
+ * by hand.
+ *
+ * <p>Only supported on a Windows <em>installed</em> build (native image). Elsewhere — Linux/macOS, or a
+ * dev/JVM run on Windows — {@link #isSupported()} is false and the UI keeps linking to the release
+ * download page instead. The install itself is unattended: the installer keeps the existing install
+ * directory (its {@code AppId} matches), {@code TrayServiceWin} closes the running app on the installer's
+ * {@code WM_CLOSE}, and the installer relaunches it via its {@code /UPDATE} {@code [Run]} entry (see
+ * {@code packaging/windows/pcpanel.iss}).
+ */
+@Log4j2
+@ApplicationScoped
+public class WindowsInstallerUpdater implements PlatformUpdater {
+    // Inno Setup silent-install switches: no UI, no message boxes, don't reboot. /UPDATE=1 is our own
+    // switch that tells the script to relaunch the app after a silent update (its [Run] "Launch now"
+    // entry is skipifsilent and would otherwise not fire).
+    private static final String[] SILENT_INSTALL_ARGS = { "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/UPDATE=1" };
+    // The Windows installer asset produced by CI is named "PCPanel-<version>-setup.exe".
+    static final Pattern SETUP_ASSET = Pattern.compile("(?i)^pcpanel-.*setup\\.exe$");
+
+    @Inject ObjectMapper objectMapper;
+    @Inject com.getpcpanel.profile.SaveService save;
+
+    @ConfigProperty(name = "pcpanel.github.user-and-repo") String githubUserAndRepo;
+    @ConfigProperty(name = "pcpanel.version") String version;
+    @ConfigProperty(name = "pcpanel.build") int build;
+
+    /** True only where an unattended installer update can run: a Windows native-image install. */
+    public boolean isSupported() {
+        return SystemUtils.IS_OS_WINDOWS && isNativeImage();
+    }
+
+    /** Download and silently install the newest available release, then restart. */
+    @Override
+    public AutoUpdateService.UpdateTarget updateToLatest() throws IOException, InterruptedException {
+        return performUpdate(resolveTarget(true));
+    }
+
+    /**
+     * Debug/testing: re-download and reinstall the <em>currently running</em> version through the exact
+     * same path, so the update mechanism can be exercised without waiting for a newer release.
+     */
+    @Override
+    public AutoUpdateService.UpdateTarget reinstallCurrent() throws IOException, InterruptedException {
+        return performUpdate(resolveTarget(false));
+    }
+
+    /**
+     * Pick the release to install and its Windows installer asset. {@code latest=true} chooses the newest
+     * release of the matching type (stable for a release build, including pre-releases for a snapshot);
+     * {@code latest=false} chooses the release that matches the currently running version.
+     */
+    private AutoUpdateService.UpdateTarget resolveTarget(boolean latest) throws IOException, InterruptedException {
+        if (!isSupported()) {
+            throw new AutoUpdateService.UpdateException("Automatic updates are only available on an installed Windows build.");
+        }
+
+        var url = "https://api.github.com/repos/" + githubUserAndRepo + "/releases?per_page=20";
+        var request = HttpRequest.newBuilder(URI.create(url)).header("Accept", "application/vnd.github+json").build();
+        var response = SharedHttpClient.get().send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() / 100 != 2) {
+            throw new AutoUpdateService.UpdateException("GitHub returned HTTP " + response.statusCode() + " while looking for the installer.");
+        }
+
+        var root = objectMapper.readTree(response.body());
+        var releases = objectMapper.treeToValue(root, Version[].class);
+        var target = chooseTarget(releases, latest, save.get().isCheckForPreReleases(), isSnapshot(), currentSemVer(), build);
+        if (target == null) {
+            throw new AutoUpdateService.UpdateException(latest
+                    ? "No suitable release was found to update to."
+                    : "Could not find a release matching the running version (" + versionDisplay() + ") to reinstall.");
+        }
+
+        var installerUrl = findInstallerAsset(root, target.id());
+        if (installerUrl == null) {
+            throw new AutoUpdateService.UpdateException("Release " + target.versionDisplay() + " has no Windows installer to download.");
+        }
+        return new AutoUpdateService.UpdateTarget(target.versionDisplay(), installerUrl);
+    }
+
+    /**
+     * Pick the release to install.
+     * <ul>
+     *   <li>{@code latest} — update to the newest available, filtered by {@code includePrereleases} (the
+     *       user's "check for pre-release versions" choice).</li>
+     *   <li>otherwise — reinstall the current version. A {@code currentIsSnapshot} build has no per-build
+     *       release to match (all snapshots share the rolling {@code latest-main} pre-release), so it
+     *       targets the newest pre-release; a release build matches its exact named release.</li>
+     * </ul>
+     */
+    static Version chooseTarget(Version[] releases, boolean latest, boolean includePrereleases, boolean currentIsSnapshot, SemVer currentSemVer, int build) {
+        if (latest) {
+            return selectLatest(releases, includePrereleases);
+        }
+        if (currentIsSnapshot) {
+            return selectLatest(releases, true); // rolling snapshot channel: no exact per-build release
+        }
+        return selectCurrent(releases, currentSemVer, false, build);
+    }
+
+    /** Newest release, optionally including pre-releases (snapshots) rather than stable-only. */
+    static Version selectLatest(Version[] releases, boolean includePrereleases) {
+        return StreamEx.of(releases)
+                       .sorted(Comparator.comparing(Version::semVer).reversed())
+                       .filter(v -> includePrereleases || !v.prerelease())
+                       .findFirst()
+                       .orElse(null);
+    }
+
+    /** The release matching the running version (same semver, and same build number for a snapshot). */
+    static Version selectCurrent(Version[] releases, SemVer currentSemVer, boolean snapshot, int build) {
+        return StreamEx.of(releases)
+                       .filter(v -> v.semVer().compareTo(currentSemVer) == 0 && (!snapshot || v.getBuild() == build))
+                       .findFirst()
+                       .orElse(null);
+    }
+
+    /** The {@code browser_download_url} of the setup asset in the release with the given id, or null. */
+    private String findInstallerAsset(JsonNode releasesRoot, int releaseId) {
+        for (var release : releasesRoot) {
+            if (release.path("id").asInt() != releaseId) {
+                continue;
+            }
+            for (var asset : release.path("assets")) {
+                var name = asset.path("name").asText("");
+                if (SETUP_ASSET.matcher(name).matches()) {
+                    return asset.path("browser_download_url").asText(null);
+                }
+            }
+        }
+        return null;
+    }
+
+    private AutoUpdateService.UpdateTarget performUpdate(AutoUpdateService.UpdateTarget target) throws IOException, InterruptedException {
+        var installer = downloadInstaller(URI.create(target.installerUrl()));
+        log.info("Update {} downloaded to {}; launching the silent installer", target.version(), installer);
+
+        var command = StreamEx.of(installer.toString()).append(SILENT_INSTALL_ARGS).toList();
+        // Start detached: the installer must outlive this process, which it closes (WM_CLOSE) and then
+        // relaunches. We do not wait for it.
+        new ProcessBuilder(command)
+                .directory(installer.getParent().toFile())
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start();
+        return target;
+    }
+
+    private Path downloadInstaller(URI installerUrl) throws IOException, InterruptedException {
+        // Not deleteOnExit: the installer runs from this file and we exit moments later (it closes us), so
+        // deleting it on shutdown could race the installer still reading it. The OS cleans %TEMP% instead.
+        var dir = Files.createTempDirectory("pcpanel-update-");
+        var fileName = installerName(installerUrl);
+        var target = dir.resolve(fileName);
+
+        // GitHub asset URLs redirect to a CDN, so this client must follow redirects (the shared client
+        // does not). Built lazily here rather than as a static field to keep it out of the native-image
+        // build heap.
+        var client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
+        var request = HttpRequest.newBuilder(installerUrl).build();
+        var response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        if (response.statusCode() / 100 != 2) {
+            throw new AutoUpdateService.UpdateException("Downloading the installer failed with HTTP " + response.statusCode() + ".");
+        }
+        try (var in = response.body()) {
+            Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+        return target;
+    }
+
+    private static String installerName(URI installerUrl) {
+        var path = installerUrl.getPath();
+        var name = path.substring(path.lastIndexOf('/') + 1);
+        return name.toLowerCase().endsWith(".exe") ? name : "PCPanel-setup.exe";
+    }
+
+    private SemVer currentSemVer() {
+        var semVer = SemVer.fromName(version);
+        return isSnapshot() ? semVer.withBuild(build) : semVer;
+    }
+
+    private boolean isSnapshot() {
+        return version.endsWith(SNAPSHOT_POSTFIX);
+    }
+
+    private String versionDisplay() {
+        return isSnapshot() ? version + " (" + build + ")" : version;
+    }
+
+    @SuppressWarnings("AccessOfSystemProperties")
+    private static boolean isNativeImage() {
+        return "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
+    }
+}

--- a/src/main/webui/src/app/pages/settings/settings.component.html
+++ b/src/main/webui/src/app/pages/settings/settings.component.html
@@ -884,7 +884,7 @@
               <div class="row">
                 <div class="row-text">
                   <div class="row-label">Re-download &amp; reinstall current version</div>
-                  <div class="row-sub">Runs the real auto-update flow against the current version: downloads its installer, runs it silently, then the app closes and restarts. For testing the update mechanism.</div>
+                  <div class="row-sub">Runs the real auto-update flow against the current version — download/apply the update the same way a newer release would, then the app closes and restarts. For testing the update mechanism.</div>
                 </div>
                 <button class="pc-btn ghost" (click)="updates.reinstallCurrent()">Reinstall</button>
               </div>

--- a/src/test/java/com/getpcpanel/util/version/WindowsInstallerUpdaterTest.java
+++ b/src/test/java/com/getpcpanel/util/version/WindowsInstallerUpdaterTest.java
@@ -9,20 +9,20 @@ import org.junit.jupiter.api.Test;
 
 import com.getpcpanel.util.version.Version.SemVer;
 
-class AutoUpdateServiceTest {
+class WindowsInstallerUpdaterTest {
     private static Version release(int id, String name, boolean prerelease) {
         return new Version(id, "https://example/" + id, name, prerelease);
     }
 
     @Test
     void setupAssetPatternMatchesTheCiArtifactOnly() {
-        assertTrue(AutoUpdateService.SETUP_ASSET.matcher("PCPanel-1.8.123-setup.exe").matches());
-        assertTrue(AutoUpdateService.SETUP_ASSET.matcher("pcpanel-2.0-setup.exe").matches());
-        assertTrue(AutoUpdateService.SETUP_ASSET.matcher("PCPanel-2.0.71-setup.exe").matches()); // real latest-main asset name
+        assertTrue(WindowsInstallerUpdater.SETUP_ASSET.matcher("PCPanel-1.8.123-setup.exe").matches());
+        assertTrue(WindowsInstallerUpdater.SETUP_ASSET.matcher("pcpanel-2.0-setup.exe").matches());
+        assertTrue(WindowsInstallerUpdater.SETUP_ASSET.matcher("PCPanel-2.0.71-setup.exe").matches()); // real latest-main asset name
         // Not the installer: the Linux artifacts, or a checksum file.
-        assertFalse(AutoUpdateService.SETUP_ASSET.matcher("PCPanel-1.8.123.AppImage").matches());
-        assertFalse(AutoUpdateService.SETUP_ASSET.matcher("pcpanel_1.8.123_amd64.deb").matches());
-        assertFalse(AutoUpdateService.SETUP_ASSET.matcher("PCPanel-setup.exe.sha256").matches());
+        assertFalse(WindowsInstallerUpdater.SETUP_ASSET.matcher("PCPanel-1.8.123.AppImage").matches());
+        assertFalse(WindowsInstallerUpdater.SETUP_ASSET.matcher("pcpanel_1.8.123_amd64.deb").matches());
+        assertFalse(WindowsInstallerUpdater.SETUP_ASSET.matcher("PCPanel-setup.exe.sha256").matches());
     }
 
     // Real release shapes from the repo: the rolling snapshot channel is one pre-release whose name
@@ -36,8 +36,8 @@ class AutoUpdateServiceTest {
         // Running build 73 (newer than the published 71): reinstall-current must still resolve, to 71,
         // instead of demanding a non-existent "build 73" release.
         var current = SemVer.fromName("2.0-SNAPSHOT").withBuild(73);
-        assertEquals(2, AutoUpdateService.chooseTarget(releases, false, true, true, current, 73).id());
-        assertEquals(2, AutoUpdateService.chooseTarget(releases, true, true, true, current, 73).id());
+        assertEquals(2, WindowsInstallerUpdater.chooseTarget(releases, false, true, true, current, 73).id());
+        assertEquals(2, WindowsInstallerUpdater.chooseTarget(releases, true, true, true, current, 73).id());
     }
 
     @Test
@@ -46,9 +46,9 @@ class AutoUpdateServiceTest {
                 release(3, "v2.1", false),
                 release(2, "v2.0", false),
         };
-        assertEquals(2, AutoUpdateService.chooseTarget(releases, false, false, false, SemVer.fromName("2.0"), -1).id());
+        assertEquals(2, WindowsInstallerUpdater.chooseTarget(releases, false, false, false, SemVer.fromName("2.0"), -1).id());
         // ...but "update to latest" jumps to the newest stable.
-        assertEquals(3, AutoUpdateService.chooseTarget(releases, true, false, false, SemVer.fromName("2.0"), -1).id());
+        assertEquals(3, WindowsInstallerUpdater.chooseTarget(releases, true, false, false, SemVer.fromName("2.0"), -1).id());
     }
 
     @Test
@@ -58,9 +58,9 @@ class AutoUpdateServiceTest {
                 release(2, "v2.0", false),
         };
         // Opted in: update jumps to the newer pre-release.
-        assertEquals(3, AutoUpdateService.chooseTarget(releases, true, true, false, SemVer.fromName("2.0"), -1).id());
+        assertEquals(3, WindowsInstallerUpdater.chooseTarget(releases, true, true, false, SemVer.fromName("2.0"), -1).id());
         // Opted out: only stable is considered, so it stays on 2.0.
-        assertEquals(2, AutoUpdateService.chooseTarget(releases, true, false, false, SemVer.fromName("2.0"), -1).id());
+        assertEquals(2, WindowsInstallerUpdater.chooseTarget(releases, true, false, false, SemVer.fromName("2.0"), -1).id());
     }
 
     @Test
@@ -70,7 +70,7 @@ class AutoUpdateServiceTest {
                 release(2, "2.0", false),
                 release(1, "1.9", false),
         };
-        assertEquals(2, AutoUpdateService.selectLatest(releases, false).id());
+        assertEquals(2, WindowsInstallerUpdater.selectLatest(releases, false).id());
     }
 
     @Test
@@ -79,7 +79,7 @@ class AutoUpdateServiceTest {
                 release(3, "2.1 (30)", true),
                 release(2, "2.0", false),
         };
-        assertEquals(3, AutoUpdateService.selectLatest(releases, true).id());
+        assertEquals(3, WindowsInstallerUpdater.selectLatest(releases, true).id());
     }
 
     @Test
@@ -88,7 +88,7 @@ class AutoUpdateServiceTest {
                 release(2, "2.0", false),
                 release(1, "1.9", false),
         };
-        assertEquals(1, AutoUpdateService.selectCurrent(releases, SemVer.fromName("1.9"), false, -1).id());
+        assertEquals(1, WindowsInstallerUpdater.selectCurrent(releases, SemVer.fromName("1.9"), false, -1).id());
     }
 
     @Test
@@ -97,12 +97,12 @@ class AutoUpdateServiceTest {
                 release(3, "2.0 (31)", true),
                 release(2, "2.0 (30)", true),
         };
-        assertEquals(2, AutoUpdateService.selectCurrent(releases, SemVer.fromName("2.0").withBuild(30), true, 30).id());
+        assertEquals(2, WindowsInstallerUpdater.selectCurrent(releases, SemVer.fromName("2.0").withBuild(30), true, 30).id());
     }
 
     @Test
     void selectCurrentReturnsNullWhenNoReleaseMatches() {
         var releases = new Version[] { release(2, "2.0", false) };
-        assertNull(AutoUpdateService.selectCurrent(releases, SemVer.fromName("1.5"), false, -1));
+        assertNull(WindowsInstallerUpdater.selectCurrent(releases, SemVer.fromName("1.5"), false, -1));
     }
 }


### PR DESCRIPTION
## Linux self-update (AppImage + Flatpak)

Adds in-place self-update for both Linux install formats, plugging into the **existing**
`AutoUpdateService` / new-version-popup / startup-auto-install framework rather than forking a parallel
system. `AutoUpdateService` becomes a thin façade that selects one `PlatformUpdater` transport by how the
app is packaged:

- **Windows** — unchanged Inno-installer logic (moved into `WindowsInstallerUpdater`).
- **AppImage** — bundled `appimageupdatetool` (zsync delta, in place) via update-info baked at build time;
  the `.zsync` is uploaded next to the AppImage.
- **Flatpak** — `flatpak update` over the host, from an OSTree repo published to the `gh-pages` branch /
  GitHub Pages with two pruned rolling refs (`stable`/`snapshot`) + `.flatpakref` install files.

`isSupported()` now returns true for AppImage/Flatpak, so the existing **Update & restart** button,
**Automatically install updates** toggle, and the **Reinstall (update-to-same-version)** debug button all
work on Linux with no UI-logic changes.

### Testing
- Backend compiles; 12 tests pass including the native-image reflection/proxy coverage guards.
- The AppImage zsync transport was validated locally (detection + block-pull).
- End-to-end GitHub-hosted verification (release `.zsync` + Pages OSTree) runs via this workflow; the
  Flatpak CI job is best-effort (`continue-on-error`) so it can never block a release.
- Flatpak updates require **GitHub Pages** enabled on the `gh-pages` branch.

### AI-assisted contributions
This change was written by an AI agent (Claude). All of the code, packaging, CI, and docs are
AI-generated. It was reviewed by the AI (compile + unit tests + a local zsync transport check); the
end-to-end CI/on-device verification is done by a human.

This pull request was made by an AI without any human intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjZYH14th2uGJAMPRRpbsf
