### PR TITLE
fix(flatpak): correct RuntimeRepo URL (dl.flathub.org/.flatpakrepo)

### DIFF
--- a/packaging/linux/flatpak/com.getpcpanel.PCPanel.snapshot.flatpakref
+++ b/packaging/linux/flatpak/com.getpcpanel.PCPanel.snapshot.flatpakref
@@ -6,4 +6,4 @@ Url=https://nvdweem.github.io/PCPanel/repo
 Homepage=https://github.com/nvdweem/PCPanel
 Comment=Community controller software for PCPanel USB audio devices (rolling snapshot channel)
 IsRuntime=false
-RuntimeRepo=https://flathub.org/repo/flathub.flatpakref
+RuntimeRepo=https://dl.flathub.org/repo/flathub.flatpakrepo

--- a/packaging/linux/flatpak/com.getpcpanel.PCPanel.stable.flatpakref
+++ b/packaging/linux/flatpak/com.getpcpanel.PCPanel.stable.flatpakref
@@ -6,4 +6,4 @@ Url=https://nvdweem.github.io/PCPanel/repo
 Homepage=https://github.com/nvdweem/PCPanel
 Comment=Community controller software for PCPanel USB audio devices (stable channel)
 IsRuntime=false
-RuntimeRepo=https://flathub.org/repo/flathub.flatpakref
+RuntimeRepo=https://dl.flathub.org/repo/flathub.flatpakrepo


### PR DESCRIPTION
The .flatpakref RuntimeRepo pointed at https://flathub.org/repo/flathub.flatpakref which 404s (wrong host + wrong file type), so `flatpak install` from the ref failed. Fixed to the canonical https://dl.flathub.org/repo/flathub.flatpakrepo.

This pull request was made by an AI without any human intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjZYH14th2uGJAMPRRpbsf