### PR TITLE
Pages: front-door landing (GitHub button) + build-free static deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,58 @@
+name: Deploy Pages site
+
+# Fast, build-free deploy of the STATIC GitHub Pages content (landing page, README, icon, and the
+# .flatpakref install files). None of these depend on the native application build, so they must not
+# require a full Build & Release run to go live — this workflow publishes them to gh-pages in seconds.
+#
+# The Flatpak OSTree repo (the actual app payload under repo/) is NOT touched here; it is regenerated
+# only by the Build & Release "Linux Flatpak" job. We publish with keep_files: true so the existing
+# repo/ directory on gh-pages is preserved while these static files are added/overwritten.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packaging/linux/flatpak/pages-index.html'
+      - 'packaging/linux/flatpak/*.flatpakref'
+      - 'README.md'
+      - 'app-icon.png'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+# One deploy at a time; a newer push supersedes an in-flight one.
+concurrency:
+  group: pages-static
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Publish static site
+    # Only on the canonical repo — forks have no gh-pages to publish to.
+    if: github.repository == 'nvdweem/PCPanel'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Stage static site
+        run: |
+          set -euxo pipefail
+          mkdir -p site
+          cp packaging/linux/flatpak/pages-index.html                     site/index.html
+          cp packaging/linux/flatpak/com.getpcpanel.PCPanel.stable.flatpakref   site/
+          cp packaging/linux/flatpak/com.getpcpanel.PCPanel.snapshot.flatpakref site/
+          cp README.md   site/README.md
+          cp app-icon.png site/app-icon.png
+          touch site/.nojekyll
+
+      # keep_files: true leaves everything already on gh-pages (crucially the OSTree repo/) in place and
+      # only writes the static files above — so this never disturbs the Flatpak payload.
+      - name: Publish to gh-pages
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages
+          keep_files: true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Turn the knobs, sliders and buttons on your [PCPanel](https://getpcpanel.com) in
 controls for everything on your PC: per-app volume, your microphone, Discord voice, OBS scenes,
 media playback, keyboard shortcuts and more.
 
+> ## 📥 [**Download & install → nvdweem.github.io/PCPanel**](https://nvdweem.github.io/PCPanel/)
+> Installation instructions and downloads for **Windows, macOS and Linux** live on the project
+> page. This README is aimed at contributors.
+
 This is **third-party, community-maintained** software for PCPanel hardware. It is a drop-in
 alternative to the official app that adds features and bug fixes requested by the community.
 

--- a/packaging/linux/flatpak/pages-index.html
+++ b/packaging/linux/flatpak/pages-index.html
@@ -11,10 +11,15 @@
   * { box-sizing: border-box; }
   body { margin:0; background:var(--bg); color:var(--fg); font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; line-height:1.5; }
   .wrap { max-width: 920px; margin:0 auto; padding: 28px 20px 60px; }
-  .hero { display:flex; gap:18px; align-items:center; margin-bottom:22px; }
-  .hero img { width:72px; height:72px; border-radius:16px; }
+  .hero { display:flex; gap:18px; align-items:flex-start; justify-content:space-between; margin-bottom:22px; }
+  .hero-title { display:flex; gap:18px; align-items:center; flex:1 1 auto; min-width:0; }
+  .hero img { width:72px; height:72px; border-radius:16px; flex-shrink:0; }
   .hero h1 { margin:0 0 4px; font-size:1.7rem; }
   .hero p { margin:0; color:var(--muted); }
+  .gh-btn { display:inline-flex; align-items:center; gap:8px; white-space:nowrap; flex-shrink:0; text-decoration:none;
+            color:var(--fg); background:var(--panel); border:1px solid var(--border); border-radius:8px;
+            padding:8px 14px; font-size:.9rem; font-weight:600; }
+  .gh-btn:hover { border-color:var(--fg); }
   .card { background:var(--panel); border:1px solid var(--border); border-radius:12px; padding:20px; margin-bottom:22px; }
   .osbar { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:16px; }
   .osbar button { cursor:pointer; background:var(--bg); color:var(--fg); border:1px solid var(--border); border-radius:999px; padding:7px 16px; font-size:.92rem; }
@@ -45,11 +50,17 @@
 <body>
 <div class="wrap">
   <div class="hero">
-    <img src="app-icon.png" alt="PCPanel icon" onerror="this.style.display='none'">
-    <div>
-      <h1>PCPanel — Community Edition</h1>
-      <p>Community controller software for PCPanel USB audio devices — per-app volume, mute, OBS, media and more.</p>
+    <div class="hero-title">
+      <img src="app-icon.png" alt="PCPanel icon" onerror="this.style.display='none'">
+      <div>
+        <h1>PCPanel — Community Edition</h1>
+        <p>Community controller software for PCPanel USB audio devices — per-app volume, mute, OBS, media and more.</p>
+      </div>
     </div>
+    <a class="gh-btn" href="https://github.com/nvdweem/PCPanel" title="View the source on GitHub">
+      <svg viewBox="0 0 16 16" width="18" height="18" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg>
+      <span>View on GitHub</span>
+    </a>
   </div>
 
   <div class="card">


### PR DESCRIPTION
- README points to the Pages site for install; landing page gets a "View on GitHub" icon-button (rendered/verified in headless Chrome).
- New pages.yml deploys the STATIC site (landing page, README, icon, .flatpakref) on push to main in seconds, preserving the OSTree repo/ — so website changes no longer need a full native app build.

Pre-release-check design left as-is per maintainer.

AI-generated. This pull request was made by an AI without any human intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjZYH14th2uGJAMPRRpbsf