### PR TITLE
Changed modifier keys on windows

### DIFF
--- a/src/main/java/com/getpcpanel/integration/keyboard/platform/windows/WindowsKeyboard.java
+++ b/src/main/java/com/getpcpanel/integration/keyboard/platform/windows/WindowsKeyboard.java
@@ -238,10 +238,10 @@ class WindowsKeyboard implements Keyboard {
     }
 
     static int modifierVk(String mod) {
-        return switch (mod) {
-            case "ctrl" -> 0x11;                       // VK_CONTROL
-            case "shift" -> 0x10;                       // VK_SHIFT
-            case "alt" -> 0x12;                         // VK_MENU
+        return switch (mod.toLowerCase()) {
+            case "ctrl" -> 0xA2;                       // VK_LCONTROL
+            case "shift" -> 0xA0;                       // VK_LSHIFT
+            case "alt" -> 0xA4;                         // VK_LMENU
             case "cmd", "command", "windows", "meta" -> 0x5B; // VK_LWIN
             default -> 0;
         };


### PR DESCRIPTION
I was checking the code for the windows keyboard handler and I noticed when submitting keys through the frontend it would sometimes submit upper-case modifier keys and cause a bad modifier key error to appear.

I also noticed the vk modifiers use the generic variant of the keys, changing it to left-aligned keys would grant better support for certain programs