### PR TITLE
feat: [GH-159] Add Elgato Master Mix Control

### DIFF
--- a/src/main/java/com/getpcpanel/integration/wavelink/WaveLinkIconHandler.java
+++ b/src/main/java/com/getpcpanel/integration/wavelink/WaveLinkIconHandler.java
@@ -15,6 +15,7 @@ import com.getpcpanel.integration.wavelink.command.CommandWaveLinkMainOutput;
 
 import dev.niels.wavelink.impl.model.WaveLinkChannel;
 import dev.niels.wavelink.impl.model.WaveLinkImage;
+import dev.niels.wavelink.impl.model.WaveLinkMix;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import lombok.extern.log4j.Log4j2;
@@ -53,6 +54,9 @@ class WaveLinkIconHandler implements IIconHandler<CommandWaveLink> {
             case Channel, Mix -> {
                 return channelImage(change.getId1());
             }
+            case MixMaster -> {
+                return mixImage(change.getId1());
+            }
             case Output -> {
                 return Optional.of(outputImage());
             }
@@ -63,6 +67,12 @@ class WaveLinkIconHandler implements IIconHandler<CommandWaveLink> {
     private Optional<BufferedImage> channelImage(@Nullable String id) {
         return Optional.ofNullable(waveLinkService.getChannels().get(id))
                        .map(WaveLinkChannel::image)
+                       .map(WaveLinkImage::getImage);
+    }
+
+    private Optional<BufferedImage> mixImage(@Nullable String id) {
+        return Optional.ofNullable(waveLinkService.getMixes().get(id))
+                       .map(WaveLinkMix::image)
                        .map(WaveLinkImage::getImage);
     }
 

--- a/src/main/java/com/getpcpanel/integration/wavelink/WaveLinkMuteResolver.java
+++ b/src/main/java/com/getpcpanel/integration/wavelink/WaveLinkMuteResolver.java
@@ -52,6 +52,7 @@ class WaveLinkMuteResolver implements MuteStateResolver {
                 var mix = channel.findMix(cmd.getId2()).orElseGet(() -> waveLink.getMixFromId(cmd.getId2()));
                 yield Optional.ofNullable(mix.isMuted());
             }
+            case MixMaster -> Optional.ofNullable(waveLink.getMixFromId(cmd.getId1()).isMuted());
             case Output -> {
                 var output = waveLink.getOutputFromId(cmd.getId1());
                 yield output.outputs() == null || output.outputs().isEmpty()

--- a/src/main/java/com/getpcpanel/integration/wavelink/command/CommandWaveLinkChangeLevel.java
+++ b/src/main/java/com/getpcpanel/integration/wavelink/command/CommandWaveLinkChangeLevel.java
@@ -56,6 +56,7 @@ public final class CommandWaveLinkChangeLevel extends CommandWaveLinkChange impl
             case Input -> service.setInputLevel(getId1(), value);
             case Channel -> service.setChannelLevel(getId1(), value);
             case Mix -> service.setChannelLevel(getId1(), getId2(), value);
+            case MixMaster -> service.setMixLevel(getId1(), value);
             case Output -> service.setOutputLevel(getId1(), value);
         }
     }

--- a/src/main/java/com/getpcpanel/integration/wavelink/command/CommandWaveLinkChangeMute.java
+++ b/src/main/java/com/getpcpanel/integration/wavelink/command/CommandWaveLinkChangeMute.java
@@ -63,7 +63,7 @@ public final class CommandWaveLinkChangeMute extends CommandWaveLinkChange imple
                 var channel = service.getChannelFromId(getId1());
                 service.setChannelMute(getId1(), muteType.convert(channel.isMuted()));
             }
-            case Mix -> {
+            case Mix -> { // Control the channel-mix combo.
                 if (StringUtils.isBlank(getId2())) {
                     log.warn("No mix id specified");
                     return;
@@ -71,6 +71,10 @@ public final class CommandWaveLinkChangeMute extends CommandWaveLinkChange imple
                 var channel = service.getChannelFromId(getId1());
                 var mix = channel.findMix(getId2()).orElseGet(() -> service.getMixFromId(getId2()));
                 service.setChannelMute(channel, mix, muteType.convert(mix.isMuted()));
+            }
+            case MixMaster -> { // Master mix control.
+                var mix = service.getMixFromId(getId1());
+                service.setMixMute(mix, muteType.convert(mix.isMuted()));
             }
             case Output -> {
                 var output = service.getOutputFromId(getId1());

--- a/src/main/java/com/getpcpanel/integration/wavelink/command/CommandWaveLinkChangeMute.java
+++ b/src/main/java/com/getpcpanel/integration/wavelink/command/CommandWaveLinkChangeMute.java
@@ -72,7 +72,12 @@ public final class CommandWaveLinkChangeMute extends CommandWaveLinkChange imple
                 var mix = channel.findMix(getId2()).orElseGet(() -> service.getMixFromId(getId2()));
                 service.setChannelMute(channel, mix, muteType.convert(mix.isMuted()));
             }
-            case MixMaster -> { // Master mix control.
+            case MixMaster -> { // Master mix control. Different from normal mix.
+                if (StringUtils.isBlank(getId1())) {
+                    log.warn("No master mix id specified");
+                    return;
+                }
+
                 var mix = service.getMixFromId(getId1());
                 service.setMixMute(mix, muteType.convert(mix.isMuted()));
             }

--- a/src/main/java/com/getpcpanel/integration/wavelink/command/WaveLinkCommandTarget.java
+++ b/src/main/java/com/getpcpanel/integration/wavelink/command/WaveLinkCommandTarget.java
@@ -1,5 +1,5 @@
 package com.getpcpanel.integration.wavelink.command;
 
 public enum WaveLinkCommandTarget {
-    Input, Channel, Mix, Output
+    Input, Channel, Mix, Output, MixMaster
 }

--- a/src/main/java/dev/niels/wavelink/IWaveLinkClient.java
+++ b/src/main/java/dev/niels/wavelink/IWaveLinkClient.java
@@ -139,8 +139,16 @@ public interface IWaveLinkClient {
 
     void setChannelAudioEffect(WaveLinkChannel channel, WaveLinkEffect effect);
 
+    default void setMixLevel(String mixId, double value) {
+        setMixLevel(getMixFromId(mixId), value);
+    }
+
     default void setMixLevel(WaveLinkMix mix, double value) {
         setMix(mix, value, null);
+    }
+
+    default void setMixMute(String mixId, boolean mute) {
+        setMixMute(getMixFromId(mixId), mute);
     }
 
     default void setMixMute(WaveLinkMix mix, boolean mute) {

--- a/src/main/webui/src/app/features/commands/command-catalog.ts
+++ b/src/main/webui/src/app/features/commands/command-catalog.ts
@@ -288,7 +288,7 @@ const FIELD_DEFS: FieldDef_[] = [
       {
         kind: 'select', key: 'commandType', label: 'Target', options: [
           { value: 'Channel', label: 'Channel' }, { value: 'Input', label: 'Input' },
-          { value: 'Mix', label: 'Mix' }, { value: 'Output', label: 'Output' },
+          { value: 'Mix', label: 'Mix' }, { value: 'MixMaster', label: 'Master Mix' }, { value: 'Output', label: 'Output' },
         ],
       },
       { kind: 'wavelink-target' },
@@ -301,7 +301,7 @@ const FIELD_DEFS: FieldDef_[] = [
       {
         kind: 'select', key: 'commandType', label: 'Target', options: [
           { value: 'Channel', label: 'Channel' }, { value: 'Input', label: 'Input' },
-          { value: 'Mix', label: 'Mix' }, { value: 'Output', label: 'Output' },
+          { value: 'Mix', label: 'Mix' }, { value: 'MixMaster', label: 'Master Mix' }, { value: 'Output', label: 'Output' },
         ],
       },
       { kind: 'wavelink-target' },

--- a/src/main/webui/src/app/features/commands/command-fields.component.ts
+++ b/src/main/webui/src/app/features/commands/command-fields.component.ts
@@ -431,6 +431,7 @@ export class CommandFieldsComponent {
     switch (this.val('commandType')) {
       case 'Input': return 'wl-inputs';
       case 'Output': return 'wl-outputs';
+      case 'MixMaster': return 'wl-mixes';
       default: return 'wl-channels';   // Channel and Mix both pick a channel first
     }
   }
@@ -438,6 +439,7 @@ export class CommandFieldsComponent {
     switch (this.val('commandType')) {
       case 'Input': return 'Input';
       case 'Output': return 'Output';
+      case 'MixMaster': return 'Master Mix';
       default: return 'Channel';
     }
   }

--- a/src/main/webui/src/app/models/generated/backend.types.ts
+++ b/src/main/webui/src/app/models/generated/backend.types.ts
@@ -1081,6 +1081,6 @@ export type SINGLE_SLIDER_MODE = "NONE" | "STATIC" | "STATIC_GRADIENT" | "VOLUME
 
 export type VolumeButton = "mute" | "next" | "prev" | "stop" | "playPause";
 
-export type WaveLinkCommandTarget = "Input" | "Channel" | "Mix" | "Output";
+export type WaveLinkCommandTarget = "Input" | "Channel" | "Mix" | "Output" | "MixMaster";
 
 export type WsEventUnion = WsAssignmentChangedEvent | WsButtonEvent | WsDeviceConnectedEvent | WsDeviceDisconnectedEvent | WsDeviceRenamedEvent | WsKnobEvent | WsLightingChangedEvent | WsProfileSwitchedEvent | WsVisualColorsChangedEvent | DeviceSnapshotDto | WsControlSettingChangedEvent | WsNewVersionAvailableEvent;


### PR DESCRIPTION
This PR is an example of how GH-159 may be done. This was hastily done using `CTRL+F` in IntelliJ and just modifying code where "Mix" was present and adding a "MixMaster" option. I **highly** recommend testing this properly or even scrapping it entirely and simply just using it as a basis for how to implement GH-159.

I don't know if I'm missing anything, and I haven't added any unit tests.

## Testing

I tested it myself by running `mvn quarkus:dev`, but I didn't try to compile it into an executable or anything like that. The implementation does work in changing the master control volume, but I didn't check too hard to see if there were any bad side-effects.

## AI Disclaimer

Most added code was written myself. Adding it was pretty much self-explanatory since you already had the other stuff for the normal mix/channels, but I did have claude help with the following:

* Figuring out how to get the icon set.
* Adding changes to this file `src/main/webui/src/app/features/commands/command-fields.component.ts`.
* Claude also cleaned up my original additions in `src/main/java/dev/niels/wavelink/IWaveLinkClient.java`. It was originally much more convoluted.